### PR TITLE
Fix vehicle spawner on older game versions

### DIFF
--- a/Solution/source/Scripting/ModelNames.cpp
+++ b/Solution/source/Scripting/ModelNames.cpp
@@ -197,29 +197,30 @@ void PopulateVehicleModelsArray()
 		{ VehicleClass::Train, &g_vehHashes_TRAIN },{ VehicleClass::Emergency, &g_vehHashes_EMERGENCY },{ VehicleClass::Motorcycle, &g_vehHashes_MOTORCYCLE },
 		{ VehicleClass::Cycle, &g_vehHashes_BICYCLE },{ VehicleClass::Plane, &g_vehHashes_PLANE },{ VehicleClass::Helicopter, &g_vehHashes_HELICOPTER },{ VehicleClass::Boat, &g_vehHashes_BOAT }
 	};
-	
+
+	const bool isMinGameVersion3095 = GTAmemory::GetGameVersion() >= eGameVersion::VER_1_0_3095_0;
 	for (int d = 0x0; d < 0x20; d++)
 	{
 		for (auto& dd : hashes[d])
 		{
 			if (std::find(g_vehHashes.begin(), g_vehHashes.end(), Model(dd)) == g_vehHashes.end())
 			{
-				if(!IS_VEHICLE_GEN9_EXCLUSIVE_MODEL(dd))
+				switch (dd)
 				{
-					switch (dd)
+					//drift vehicles from Chop Shop DLC
+					case VEHICLE_DRIFTTAMPA:
+					case VEHICLE_DRIFTYOSEMITE:
+					case VEHICLE_DRIFTJESTER:
+					case VEHICLE_DRIFTEUROS:
+					case VEHICLE_DRIFTREMUS:
+					case VEHICLE_DRIFTFUTO:
+					case VEHICLE_DRIFTZR350:
+					case VEHICLE_DRIFTFR36:
+						g_vehHashes_DRIFT.push_back(dd);
+					break;
+				default:
+					if(!isMinGameVersion3095 || !IS_VEHICLE_GEN9_EXCLUSIVE_MODEL(dd))
 					{
-						//drift vehicles from Chop Shop DLC
-						case VEHICLE_DRIFTTAMPA:
-						case VEHICLE_DRIFTYOSEMITE:
-						case VEHICLE_DRIFTJESTER:
-						case VEHICLE_DRIFTEUROS:
-						case VEHICLE_DRIFTREMUS:
-						case VEHICLE_DRIFTFUTO:
-						case VEHICLE_DRIFTZR350:
-						case VEHICLE_DRIFTFR36:
-							g_vehHashes_DRIFT.push_back(dd);
-						break;
-					default:
 						auto dit = vDestMap.find(VehicleClass(d));
 						if (dit != vDestMap.end())
 							dit->second->push_back(dd);

--- a/Solution/source/Submenus/WeaponOptions.cpp
+++ b/Solution/source/Submenus/WeaponOptions.cpp
@@ -760,6 +760,7 @@ namespace sub
 		AddvcatOption_("SUVs", Indices::SUV);
 		AddvcatOption_("Sedans", Indices::SEDAN);
 		AddvcatOption_("Compacts", Indices::COMPACT);
+		AddvcatOption_("Drift", Indices::DRIFT);
 
 		AddBreak("---Industrial---");
 		AddvcatOption_("Vans", Indices::VAN);
@@ -774,7 +775,6 @@ namespace sub
 		AddvcatOption_("Military", Indices::MILITARY);
 		AddvcatOption_("Motorcycles", Indices::MOTORCYCLE);
 		AddvcatOption_("Bicycles", Indices::BICYCLE);
-		AddvcatOption_("Drift", Indices::DRIFT);
 		AddvcatOption_("Others", Indices::OTHER);
 
 		/*PCHAR chartick;


### PR DESCRIPTION
fixes issue https://github.com/itsjustcurtis/MenyooSP/issues/9

and moved new drift category to correct place in WeaponOptions.cpp

Testet in Singleplayer (b3095) and FiveM (b2944 & b3095)

