### PR TITLE
Add freemode peds back to Multiplayer Category

### DIFF
--- a/Solution/source/_Build/bin/Release/menyooStuff/PedList.xml
+++ b/Solution/source/_Build/bin/Release/menyooStuff/PedList.xml
@@ -793,6 +793,8 @@
 		<Ped name="mp_s_m_armoured_01" caption="Armoured Van Security Male" />
   		<Ped name="mp_m_weapexp_01" caption="Weapon Exp (Male)" />
   		<Ped name="mp_m_weapwork_01" caption="Weapon Work (Male)" />
+		<Ped name="mp_f_freemode_01" caption="Freemode MP Female" />
+		<Ped name="mp_m_freemode_01" caption="Freemode MP Male" />
 	</Category>
 	<Category name="ScenarioFemale">
 		<Ped name="s_f_m_autoshop_01" caption="Autoshop Worker Female" />


### PR DESCRIPTION
I had previously removed them and moved them to the Players category, however that doesn't seem to appear in game. Perhaps I mispelt it or broke it?