### PR TITLE
fixed teleport via marker after leaving a vehicle

### DIFF
--- a/Solution/source/Submenus/Spooner/MarkerManagement.cpp
+++ b/Solution/source/Submenus/Spooner/MarkerManagement.cpp
@@ -40,7 +40,7 @@ namespace sub::Spooner
 			GTAentity myPed = PLAYER_PED_ID();
 			GTAentity myVehicle = GET_VEHICLE_PED_IS_IN(myPed.Handle(), false);
 			GTAentity* entityToTeleport = &myPed;
-			bool bMyPedIsInVehicle = myVehicle.Exists();
+			bool bMyPedIsInVehicle = IS_PED_IN_VEHICLE(myPed.Handle(), myVehicle.Handle(), false);
 
 			const Vector3& myDim1 = myPed.Dim1();
 			Vector3 myVehicleDim1;


### PR DESCRIPTION
The problem was that the bool `bMyPedIsInVehicle` was still true after exiting a vehicle, because the last vehicle still exists
changed to a check if the player is in the last entered vehicle

Fix https://github.com/itsjustcurtis/MenyooSP/issues/96