### PR TITLE
prevent attach entity to entity if already attached

### DIFF
--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -1551,16 +1551,25 @@ namespace sub
 						{
 							if (e.Handle.Exists())
 							{
-								bool bEntityPressed = false;
-								AddOption(e.HashName, bEntityPressed); if (bEntityPressed)
+								if (!SelectedEntity.Handle.IsAttachedTo(e.Handle))
 								{
-									EntityManagement::AttachEntityInit(SelectedEntity, e.Handle, Settings::bKeepPositionWhenAttaching);
-									Menu::SetSub_previous();
-									return;
+									bool bEntityPressed = false;
+									AddOption(e.HashName, bEntityPressed); if (bEntityPressed)
+									{
+										EntityManagement::AttachEntityInit(SelectedEntity, e.Handle, Settings::bKeepPositionWhenAttaching);
+										Menu::SetSub_previous();
+										return;
+									}
+									if (*Menu::currentopATM == Menu::printingop)
+										EntityManagement::ShowArrowAboveEntity(e.Handle, RGBA(0, 255, 0, 200));
 								}
-
-								if (*Menu::currentopATM == Menu::printingop)
-									EntityManagement::ShowArrowAboveEntity(e.Handle, RGBA(0, 255, 0, 200));
+								else
+								{
+									AddOption(e.HashName + " (already attached)", null);
+									if (*Menu::currentopATM == Menu::printingop)
+										EntityManagement::ShowArrowAboveEntity(e.Handle, RGBA(255, 0, 0, 200));
+								}
+								
 							}
 							else
 							{


### PR DESCRIPTION
- prevents attach entity to entity if already attached
- marked attached entity with red instead of green marker
- add `(already attached)` to HashName 

Fix https://github.com/itsjustcurtis/MenyooSP/issues/60

![image](https://github.com/user-attachments/assets/a8602400-bb85-4eca-8363-3df41addb4bc)
