### PR TITLE
Fixed the issue where the log file kept writing the same information

### DIFF
--- a/Solution/source/Menu/Language.cpp
+++ b/Solution/source/Menu/Language.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * Menyoo PC - Grand Theft Auto V single-player trainer mod
 * Copyright (C) 2019  MAFINS
 *
@@ -15,6 +15,7 @@
 
 #include <fstream>
 #include <json\single_include\nlohmann\json.hpp>
+#include <set>
 using Json = nlohmann::json;
 
 namespace Language
@@ -33,14 +34,20 @@ namespace Language
 
 	std::string Lang::Translate(std::string text)
 	{
-		try
-		{
+		static std::set<std::string> reported_missing;
+
+		try {
 			auto& ret = this->pairs.at(text);
 			return ret;
 		}
-		catch (std::out_of_range)
-		{
-			addlog(ige::LogType::LOG_ERROR, "Translate string out of range: " + text, __FILENAME__);
+		catch (std::out_of_range) {
+			if(reported_missing.insert(text).second) {
+				addlog(ige::LogType::LOG_ERROR, 
+					   "Missing translation for: " + text, 
+					   __FILENAME__);
+			}
+			this->pairs[text] = text;
+
 			return text;
 		}
 	}

--- a/Solution/source/Util/FileLogger.cpp
+++ b/Solution/source/Util/FileLogger.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * Menyoo PC - Grand Theft Auto V single-player trainer mod
 * Copyright (C) 2019  MAFINS
 *
@@ -14,6 +14,8 @@
 #include <fstream>
 #include <iomanip>
 #include <time.h>
+#include <map>
+#include <set>
 #include "../Natives/natives.h"
 #include "../Menu/Menu.h"
 #include "../Menu/MenuConfig.h"
@@ -22,6 +24,14 @@ namespace ige
 {
 	FileLogger menyooLogObject("menyooLog.txt");
 	std::ofstream& myLog = menyooLogObject.myFile;
+
+    static std::set<std::string> logged_errors;
+
+    struct ErrorCount {
+        int count;
+        time_t first_occurrence; 
+    };
+    static std::map<std::string, ErrorCount> error_counts;
 
 	FileLogger::FileLogger(std::string fname)
 	{
@@ -35,7 +45,6 @@ namespace ige
 			localtime_s(&t, &now);
 
 			myFile << "Menyoo " << MENYOO_CURRENT_VER_ << std::endl;
-			//myFile << "Player Name: " << PLAYER::GET_PLAYER_NAME(-1) << std::endl;
 			myFile << "Log file created " << std::setfill('0') << std::setw(2) << t.tm_mday << "/" << std::setfill('0') << std::setw(2) << (t.tm_mon + 1) << "/" << t.tm_year + 1900 << std::endl;
 			myFile << "Logging level " << std::to_string(g_loglevel) << " active. Edit loglevel in menyooconfig.ini to change." << std::endl << std::endl;
 		}
@@ -53,14 +62,69 @@ namespace ige
 
 	}
 
-	void addlog(LogType logType, std::string message, std::string filename, int loglevel)
-	{
-		if (static_cast<int>(logType) <= loglevel)
-		{
-			ige::myLog << logType << (loglevel >= 3 ? filename : "") << ": " << message << std::endl;
-		}
-	}
+    struct TranslationEntry {
+        std::string original;
+        std::string translated;
+        bool hasTranslation;
+    };
+    
+    static std::map<std::string, TranslationEntry> translation_table;
+    
+    struct LogControl {
+        int threshold;      // 输出阈值
+        int interval;       // 输出间隔
+        time_t cooldown;    // 冷却时间(秒)
+    };
+    static LogControl log_control = {100, 1000, 3600}; // 默认值
+    
+    void addlog(LogType logType, std::string message, std::string filename, int loglevel) 
+    {
+        if(message.find("Translate string out of range:") == 0) {
+            std::string key = message.substr(27); // 提取需要翻译的文本
+            
+            auto& entry = translation_table[key];
+            if(!entry.hasTranslation) {
+                entry.original = key;
+                entry.translated = key; // 使用原文作为默认翻译
+                entry.hasTranslation = true;
+                
+                ige::myLog << LogType::LOG_WARNING 
+                          << ": New untranslated string: " << key << std::endl;
+            }
+            
+            auto& count = error_counts[key];
+            if(count.count == 0) {
+                count.first_occurrence = time(0);
+            }
+            count.count++;
+            
+            time_t now = time(0);
+            if(count.count == 1 || 
+               (count.count % log_control.threshold == 0 && 
+                now - count.first_occurrence >= log_control.cooldown)) {
+                
+                ige::myLog << logType << (loglevel >= 3 ? filename : "")
+                          << ": Translation missing for '" << key 
+                          << "' (occurred " << count.count 
+                          << " times in " 
+                          << (now - count.first_occurrence) / 3600.0 
+                          << " hours)" << std::endl;
+            }
+            return;
+        }
 
+        if(static_cast<int>(logType) <= loglevel) {
+            ige::myLog << logType << (loglevel >= 3 ? filename : "") 
+                      << ": " << message << std::endl;
+        }
+    }
+
+    void AddTranslation(const std::string& key, const std::string& value) {
+        auto& entry = translation_table[key];
+        entry.original = key;
+        entry.translated = value;
+        entry.hasTranslation = true;
+    }
 	//overloaded function to define default file and loglevels unless otherwise specified
 	void addlog(LogType logType, std::string& message) {
 		addlog(logType, message, "", g_loglevel);


### PR DESCRIPTION
Change it to record only once.
If your native language is English, you may not find this problem. I used an external translation file json to translate the menu into my language. When I open the menu, an error message will be written to the menyooLog file for each frame. As long as you stay on the current menu page, it will repeatedly write the same message for each menu line, like this:

[01:45:20] ERROR - : Translate string out of range: ac_ig_3_p3_b
[01:45:20] ERROR - : Translate string out of range: ac_ig_3_p3_b
[01:45:20] ERROR - : Translate string out of range: ac_ig_3_p3_b
[01:45:20] ERROR - : Translate string out of range: ah_1_ext_t6
[01:45:20] ERROR - : Translate string out of range: ah_1_ext_t6
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial
[01:12:49] ERROR - : Translate string out of range: Military
[01:12:49] ERROR - : Translate string out of range: Commercial

After I modified:
After I modified:
[12:16:55] WARNING - : New untranslated string: ge: 杰诺
[12:16:55] ERROR - : Translation missing for 'ge: 杰诺' (occurred 1 times in 0 hours)
[12:16:55] WARNING - : New untranslated string: ge: bullfighting µXO
[12:16:55] ERROR - : Translation missing for 'ge: BullfightµXO' (occurred 1 times in 0 hours)
[12:16:55] WARNING - : New untranslated string: ge: Essence µMT
[12:16:55] ERROR - : Translation missing for 'ge:essenceµMT' (occurred 1 times in 0 hours)