### PR TITLE
New Blip features

### DIFF
--- a/Solution/source/Scripting/GTAblip.cpp
+++ b/Solution/source/Scripting/GTAblip.cpp
@@ -32,6 +32,9 @@ namespace BlipIcon {
 	const std::map<int, std::string> vNames
 	{
 		{ BlipIcon::Standard, "Standard" },
+		{ BlipIcon::Enemy, "Enemy" },
+		{ BlipIcon::Friend, "Friend" },
+		{ BlipIcon::VIP, "VIP" },
 		{ BlipIcon::BigBlip, "BigBlip" },
 		{ BlipIcon::PoliceOfficer, "PoliceOfficer" },
 		{ BlipIcon::PoliceArea, "PoliceArea" },
@@ -196,7 +199,6 @@ namespace BlipIcon {
 		{ BlipIcon::PropertyManagement, "PropertyManagement" },
 		{ BlipIcon::GangHighlight, "GangHighlight" },
 		{ BlipIcon::Altruist, "Altruist" },
-		{ BlipIcon::Enemy, "Enemy" },
 		{ BlipIcon::OnMission, "OnMission" },
 		{ BlipIcon::CashPickup, "CashPickup" },
 		{ BlipIcon::Chop, "Chop" },
@@ -205,7 +207,6 @@ namespace BlipIcon {
 		{ BlipIcon::CashPickupVagos, "CashPickupVagos" },
 		{ BlipIcon::CashPickupPolice, "CashPickupPolice" },
 		{ BlipIcon::Hooker, "Hooker" },
-		{ BlipIcon::Friend, "Friend" },
 		{ BlipIcon::CustodyDropoff, "CustodyDropoff" },
 		{ BlipIcon::OnMissionPolice, "OnMissionPolice" },
 		{ BlipIcon::OnMissionLost, "OnMissionLost" },
@@ -348,7 +349,6 @@ namespace BlipIcon {
 		{ BlipIcon::Truck, "Truck" },
 		{ BlipIcon::SpecialCargo, "SpecialCargo" },
 		{ BlipIcon::Trailer, "Trailer" },
-		{ BlipIcon::VIP, "VIP" },
 		{ BlipIcon::Cargobob, "Cargobob" },
 		{ BlipIcon::AreaCutline, "AreaCutline" },
 		{ BlipIcon::Jammed, "Jammed" },
@@ -855,7 +855,32 @@ void GTAblip::ShowRoute(bool value)
 {
 	SET_BLIP_ROUTE(this->mHandle, value);
 }
+// New Blip functions
+void GTAblip::ShowCone(bool toggle, int hudColorIndex)
+{
+    SET_BLIP_SHOW_CONE(this->mHandle, toggle, hudColorIndex);
+}
 
+void GTAblip::SetDisplay(int displayId)
+{
+    SET_BLIP_DISPLAY(this->mHandle, displayId);
+}
+
+void GTAblip::SetPriority(int priority)
+{
+    SET_BLIP_PRIORITY(this->mHandle, priority);
+}
+
+void GTAblip::SetRotationWithFloat(float heading)
+{
+    SET_BLIP_ROTATION_WITH_FLOAT(this->mHandle, heading);
+}
+
+void GTAblip::AddBlipForArea(float x, float y, float z, float width, float height)
+{
+    this->mHandle = ADD_BLIP_FOR_AREA(x, y, z, width, height);
+}
+// New Blip functions end here.
 int GTAblip::Icon() const
 {
 	return GET_BLIP_SPRITE(this->mHandle);

--- a/Solution/source/Scripting/GTAblip.cpp
+++ b/Solution/source/Scripting/GTAblip.cpp
@@ -931,6 +931,8 @@ bool GTAblip::Exists() const
 	return DOES_BLIP_EXIST(this->mHandle) != 0;
 }
 void GTAblip::Remove()
+}
+
 {
 	if (DOES_BLIP_EXIST(this->mHandle))
 	{
@@ -938,4 +940,13 @@ void GTAblip::Remove()
 		REMOVE_BLIP(&id);
 		this->mHandle = id;
 	}
+}
+//New code to add rotational sync with attached entity.
+void GTAblip::SyncRotationWithEntity(int entityHandle)
+{
+    if (DOES_BLIP_EXIST(this->mHandle) && DOES_ENTITY_EXIST(entityHandle))
+    {
+        float entityHeading = GET_ENTITY_HEADING(entityHandle); // Get entity rotation
+        SET_BLIP_ROTATION_WITH_FLOAT(this->mHandle, entityHeading); // Set blip rotation
+    }
 }

--- a/Solution/source/Scripting/GTAblip.h
+++ b/Solution/source/Scripting/GTAblip.h
@@ -895,6 +895,8 @@ public:
 
 	void SetScale(float value);
 
+//New functions
+
 	void ShowCone(bool toggle, int hudColorIndex);
 
 	void SetDisplay(int displayId);
@@ -906,6 +908,8 @@ public:
 	void AddBlipForArea(float x, float y, float z, float width, float height);
 
 	void SyncRotationWithEntity(int entityHandle);
+
+//New functions end here
 
 	void ShowRoute(bool value);
 

--- a/Solution/source/Scripting/GTAblip.h
+++ b/Solution/source/Scripting/GTAblip.h
@@ -895,6 +895,18 @@ public:
 
 	void SetScale(float value);
 
+	void ShowCone(bool toggle, int hudColorIndex);
+
+	void SetDisplay(int displayId);
+
+	void SetPriority(int priority);
+
+	void SetRotationWithFloat(float heading);
+
+	void AddBlipForArea(float x, float y, float z, float width, float height);
+
+	void SyncRotationWithEntity(int entityHandle);
+
 	void ShowRoute(bool value);
 
 	int Icon() const;

--- a/Solution/source/Submenus/Spooner/STSTasks.cpp
+++ b/Solution/source/Submenus/Spooner/STSTasks.cpp
@@ -105,6 +105,13 @@ namespace sub::Spooner
 			nodeTask.append_child("IsShortRange").text() = this->isShortRange;
 			nodeTask.append_child("ShowRoute").text() = this->showRoute;
 			nodeTask.append_child("ShowNumber").text() = this->showNumber;
+			// New Functions
+			nodeTask.append_child("ShowCone").text() = this->showCone;
+    			nodeTask.append_child("HudColorIndex").text() = this->hudColorIndex;
+    			nodeTask.append_child("DisplayId").text() = this->displayId;
+    			nodeTask.append_child("Priority").text() = this->priority;
+    			nodeTask.append_child("SyncRotation").text() = this->syncRotation;
+
 		}
 		void AddBlip::ImportXmlNodeTaskSpecific(pugi::xml_node& nodeTask)
 		{
@@ -118,6 +125,12 @@ namespace sub::Spooner
 			this->isShortRange = nodeTask.child("IsShortRange").text().as_bool();
 			this->showRoute = nodeTask.child("ShowRoute").text().as_bool();
 			this->showNumber = nodeTask.child("ShowNumber").text().as_int();
+			// New Functions
+			this->showCone = nodeTask.child("ShowCone").text().as_bool();
+    			this->hudColorIndex = nodeTask.child("HudColorIndex").text().as_int();
+    			this->displayId = nodeTask.child("DisplayId").text().as_int();
+    			this->priority = nodeTask.child("Priority").text().as_int();
+    			this->syncRotation = nodeTask.child("SyncRotation").text().as_bool();
 		}
 		void AddBlip::ImportTaskDataSpecific(STSTask* otherTsk)
 		{
@@ -173,7 +186,16 @@ namespace sub::Spooner
 				this->blip.ShowRoute(this->showRoute);
 				if (this->showNumber != 0)
 					this->blip.ShowNumber(this->showNumber);
-			}
+				// New Functions
+        			this->blip.SetBlipShowCone(this->showCone, this->hudColorIndex);
+        			this->blip.SetBlipDisplay(this->displayId);
+        			this->blip.SetBlipPriority(this->priority);
+
+        			if (this->syncRotation)
+        			{
+            			this->blip.SyncRotationWithEntity(e.Handle.Entity());
+        			}
+    			}
 		}
 
 		RemoveBlip::RemoveBlip()

--- a/Solution/source/Submenus/Spooner/STSTasks.h
+++ b/Solution/source/Submenus/Spooner/STSTasks.h
@@ -78,6 +78,12 @@ namespace sub::Spooner
 			bool isShortRange;
 			bool showRoute;
 			int showNumber;
+			// New functions
+    			bool showCone;            
+    			int hudColorIndex;      
+    			int displayId;         
+    			int priority;         
+    			bool syncRotation;  
 			AddBlip();
 			void Run(void* ve) override;
 		};

--- a/Solution/source/Submenus/Spooner/Submenus_TaskSequence.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus_TaskSequence.cpp
@@ -166,6 +166,20 @@ namespace sub::Spooner
 				AddTexter("Display Number", tskPtr->showNumber, std::vector<std::string>{""}, null, number_plus, number_minus);
 				if (number_plus) { if (tskPtr->showNumber < INT_MAX) tskPtr->showNumber++; }
 				if (number_minus) { if (tskPtr->showNumber > INT_MIN) tskPtr->showNumber--; }
+
+				AddToggle("Show Cone", tskPtr->showCone);
+				
+    				bool displayId_plus = false, displayId_minus = false;
+   				AddNumber("Display ID", tskPtr->displayId, 1, null, displayId_plus, displayId_minus);
+    				if (displayId_plus) { if (tskPtr->displayId < INT_MAX) tskPtr->displayId++; }
+    				if (displayId_minus) { if (tskPtr->displayId > 0) tskPtr->displayId--; }
+
+    				bool priority_plus = false, priority_minus = false;
+    				AddNumber("Priority", tskPtr->priority, 1, null, priority_plus, priority_minus);
+    				if (priority_plus) { if (tskPtr->priority < INT_MAX) tskPtr->priority++; }
+    				if (priority_minus) { if (tskPtr->priority > 0) tskPtr->priority--; }
+
+    AddToggle("Sync Rotation With Entity", tskPtr->syncRotation);
 			}
 			void RemoveBlip()
 			{


### PR DESCRIPTION
Very experimental features added for blips.
I have no coding experience at all, so expect crude design. I did my best.
_I would personally recommend testing this in a new branch just in case._

Added;
Toggle for cones (like NPC vision, likely won't function but it's there for the aesthetic).

Toggle to make blips not selectable on the map.

Set blip priority.

Toggle to allow blip rotation.

Toggle (hopefully just a toggle) to have a blip to mark an area.

Changes;
Moved Enemy, Friend, and VIP to the top