### PR TITLE
Remove unnecessary patch that causes random crashes near LSC

### DIFF
--- a/Solution/source/Memory/GTAmemory.cpp
+++ b/Solution/source/Memory/GTAmemory.cpp
@@ -1492,30 +1492,6 @@ void GTAmemory::Init()
 		_gamePlayCameraAddr = reinterpret_cast<UINT64*>(*reinterpret_cast<int*>(address + 3) + address + 7);
 	}
 
-
-
-	// Bypass model requests block
-	if (g_isEnhanced) {
-		address = MemryScan::PatternScanner::FindPattern("44 0f b6 b4 24 ? ? ? ? 41 20 f6");
-		if (address) memset(reinterpret_cast<void*>(address - 20), 0x90, 20);
-	}
-	else {
-		// new pattern that lands outside of the patched bytes, to ensure compatibility with other mods that patch them.
-		address = MemryScan::PatternScanner::FindPattern("45 84 e4 74 ? e8 ? ? ? ? 48 85 c0");
-		if (address) memset(reinterpret_cast<void*>(address - 24), 0x90, 24);
-	}
-
-	// Bypass is player model allowed to spawn checks
-	if (g_isEnhanced) {
-		address = MemryScan::PatternScanner::FindPattern("74 ? e8 ? ? ? ? 48 8b b0");
-		if (address) memset(reinterpret_cast<void*>(address + 28), 0x90, 6);
-	}
-	else {
-		// new pattern that lands outside of the patched bytes, to ensure compatibility with other mods that patch them.
-		address = MemryScan::PatternScanner::FindPattern("40 53 48 83 ec ? e8 ? ? ? ? 48 8b d8 48 85 c0 74 ? 48 8b 10 48 8b c8 ff 52");
-		if (address) memset(reinterpret_cast<void*>(address + 28), 0x90, 4);
-	}
-
 	//GetModelInfo
 
 	if (g_isEnhanced) {

--- a/Solution/source/Memory/GTAmemory.cpp
+++ b/Solution/source/Memory/GTAmemory.cpp
@@ -1492,6 +1492,17 @@ void GTAmemory::Init()
 		_gamePlayCameraAddr = reinterpret_cast<UINT64*>(*reinterpret_cast<int*>(address + 3) + address + 7);
 	}
 
+	// Bypass model requests block
+	if (g_isEnhanced) {
+		address = MemryScan::PatternScanner::FindPattern("44 0f b6 b4 24 ? ? ? ? 41 20 f6");
+		if (address) memset(reinterpret_cast<void*>(address - 20), 0x90, 20);
+	}
+	else {
+		// new pattern that lands outside of the patched bytes, to ensure compatibility with other mods that patch them.
+		address = MemryScan::PatternScanner::FindPattern("45 84 e4 74 ? e8 ? ? ? ? 48 85 c0");
+		if (address) memset(reinterpret_cast<void*>(address - 24), 0x90, 24);
+	}
+
 	//GetModelInfo
 
 	if (g_isEnhanced) {


### PR DESCRIPTION
This patch is not necessary for single player and causes the game to crash randomly when going near LS customs on game versions 1.0.3717.0 / 1.0.1013.17 or newer.