### PR TITLE
Fix: Language system crash when ScriptHookVDotNet is installed

### DIFF
--- a/Solution/source/Menu/Language.cpp
+++ b/Solution/source/Menu/Language.cpp
@@ -36,20 +36,17 @@ namespace Language
 	{
 		static std::set<std::string> reported_missing;
 
-		try {
-			auto& ret = this->pairs.at(text);
-			return ret;
+		auto it = this->pairs.find(text);
+		if (it != this->pairs.end()) {
+			return it->second;
 		}
-		catch (std::out_of_range) 
-		{
-			if(reported_missing.insert(text).second) 
-			{
-				addlog(ige::LogType::LOG_ERROR, "Missing translation for: " + text);
-			}
-			this->pairs[text] = text;
 
-			return text;
+		if (reported_missing.insert(text).second)
+		{
+			addlog(ige::LogType::LOG_ERROR, "Missing translation for: " + text);
 		}
+		this->pairs[text] = text;
+		return text;
 	}
 
 	std::string TranslateToSelected(std::string text)


### PR DESCRIPTION
## Summary

Replaces `std::map::at()` with `std::map::find()` in `Lang::Translate()` (`Language.cpp`) to fix a crash that occurs when using **any** language file while ScriptHookVDotNet (SHVDN) is also installed.

This has been a known issue for years — the common workaround has been "remove ScriptHookVDotNet", which isn't practical for most users.

## The Problem

When a language file is loaded, `Lang::Translate()` throws `std::out_of_range` for every missing translation key via `std::map::at()`. Normally this is caught gracefully, but when SHVDN is present:

1. The .NET CLR installs a process-wide **Vectored Exception Handler**
2. This handler intercepts the C++ exception **before** Menyoo's `catch` block
3. Since ScriptHookV runs scripts inside **fibers**, the CLR's stack check fails (fiber stack ≠ thread stack)
4. CLR calls `DontCallDirectlyForceStackOverflow` → crash

```
CORE: An exception occurred while executing 'Menyoo.asi', id 3
Exception addr 0x00007FFEBEFE8BC0 is clr.dll+0x005F8BC0
Last called native 0x0000000000000000
```

See: scripthookvdotnet/scripthookvdotnet#976

## The Fix

```diff
- try {
-     auto& ret = this->pairs.at(text);
-     return ret;
- }
- catch (std::out_of_range) { ... }
+ auto it = this->pairs.find(text);
+ if (it != this->pairs.end()) {
+     return it->second;
+ }
+ // fallback: log, cache, and return original
```

`std::map::find()` performs the same lookup without throwing exceptions. Behavior is otherwise identical — missing keys are still logged and cached.

## Testing

- Tested with Menyoo 2.2.2 + ScriptHookVDotNet + a Japanese translation file (5,234 entries)
- Confirmed the crash no longer occurs
- All menu translations display correctly
- No regressions observed