### PR TITLE
Fix clash with xyzh display

### DIFF
--- a/Solution/source/Menu/Routine.cpp
+++ b/Solution/source/Menu/Routine.cpp
@@ -1845,11 +1845,11 @@ void XYZH()
 	Vector3 Pos = GET_ENTITY_COORDS(PLAYER_PED_ID(), 1);
 
 	Game::Print::SetupDraw(font_xyzh, Vector2(0.35f, 0.36f), false, false, true);
-	Game::Print::drawstring("Coords:", 0.90f, 0.066f);
-	xyzhDrawFloat(Pos.x, 0.90f, 0.10f);
-	xyzhDrawFloat(Pos.y, 0.90f, 0.13f);
-	xyzhDrawFloat(Pos.z, 0.90f, 0.16f);
-	xyzhDrawFloat(GET_ENTITY_HEADING(PLAYER_PED_ID()), 0.90f, 0.19f);
+	Game::Print::drawstring("Coords:", 0.94f, 0.03f);
+	xyzhDrawFloat(Pos.x, 0.94f, 0.06f);
+	xyzhDrawFloat(Pos.y, 0.94f, 0.09f);
+	xyzhDrawFloat(Pos.z, 0.94f, 0.12f);
+	xyzhDrawFloat(GET_ENTITY_HEADING(PLAYER_PED_ID()), 0.94f, 0.15f);
 }
 
 void SetLocalSupermanManual()

--- a/Solution/source/Misc/FpsCounter.cpp
+++ b/Solution/source/Misc/FpsCounter.cpp
@@ -56,7 +56,7 @@ namespace FPSCounter
 	{
 		g_fpsCounter.Tick();
 		Game::Print::SetupDraw(GTAfont::Impact, Vector2(0.4f, 0.4f), false, false, false);
-		Game::Print::drawstring("~y~" + g_fpsCounter.GetString() + " FPS", 0.945f, 0.034f);
+		Game::Print::drawstring("~y~" + g_fpsCounter.GetString() + " FPS", 0.965f, 0.008f);
 	}
 
 	void DisplayFpsTick()

--- a/Solution/source/Submenus/Spooner/SpoonerMode.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.cpp
@@ -42,6 +42,7 @@
 #include <utility>
 #include <set>
 #include <math.h>
+#include <Menu/Routine.h>
 
 namespace sub::Spooner
 {
@@ -269,15 +270,16 @@ namespace sub::Spooner
 						}
 					}
 					bool bRightJus = get_xcoord_at_menu_leftEdge(0.0f, false) < 0.5f; // left edge of menu is on the left of the centre of the screen
-					float infoX = bRightJus ? 0.94f : 0.008f;
-					Game::Print::SetupDraw(GTAfont::Arial, Vector2(0.37f, 0.37f), false, bRightJus, false);
-					Game::Print::drawstring("Total Entities Spawned: " + std::to_string(totalNumEntities), infoX, 0.064f);
-					Game::Print::SetupDraw(GTAfont::Arial, Vector2(0.37f, 0.37f), false, bRightJus, false);
-					Game::Print::drawstring("Objects Spawned: " + std::to_string(totalNumProps), infoX, 0.094f);
-					Game::Print::SetupDraw(GTAfont::Arial, Vector2(0.37f, 0.37f), false, bRightJus, false);
-					Game::Print::drawstring("Peds Spawned: " + std::to_string(totalNumPeds), infoX, 0.124f);
-					Game::Print::SetupDraw(GTAfont::Arial, Vector2(0.37f, 0.37f), false, bRightJus, false);
-					Game::Print::drawstring("Vehicles Spawned: " + std::to_string(totalNumVehicles), infoX, 0.154f);
+					float infoX = bRightJus ? 0.90f : 0.008f;
+					float infoY = xyzhCoords ? 0.184f : 0.064f;
+					Game::Print::SetupDraw(font_xyzh, Vector2(0.37f, 0.37f), false, bRightJus, true);
+					Game::Print::drawstring("Total Entities Spawned: " + std::to_string(totalNumEntities), infoX, infoY);
+					Game::Print::SetupDraw(font_xyzh, Vector2(0.37f, 0.37f), false, bRightJus, true);
+					Game::Print::drawstring("Objects Spawned: " + std::to_string(totalNumProps), infoX, infoY + 0.03f);
+					Game::Print::SetupDraw(font_xyzh, Vector2(0.37f, 0.37f), false, bRightJus, true);
+					Game::Print::drawstring("Peds Spawned: " + std::to_string(totalNumPeds), infoX, infoY + 0.06f);
+					Game::Print::SetupDraw(font_xyzh, Vector2(0.37f, 0.37f), false, bRightJus, true);
+					Game::Print::drawstring("Vehicles Spawned: " + std::to_string(totalNumVehicles), infoX, infoY + 0.09f);
 				}
 
 				if (!freeCam.Exists())

--- a/Solution/source/macros.h
+++ b/Solution/source/macros.h
@@ -17,7 +17,7 @@
 
 
 
-#define MENYOO_CURRENT_VER_ "2.3.0a8"
+#define MENYOO_CURRENT_VER_ "2.3.0a9"
 
 #define GAME_PLAYERCOUNT 30
 


### PR DESCRIPTION
* Move Spooner Display up slightly
* Add dynamic movement of Spooner Display when xyzh is enabled
* Moved xyzh default position to be less intrusive
* Made Spooner font consistent with xyzh font
* Moved FPS Counter up to accomodate new positioning.