### PR TITLE
fix: preserve ped overlay color when changing variants

### DIFF
--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -1132,7 +1132,7 @@ namespace sub
 				}
 
 				SET_PED_HEAD_OVERLAY(ped.Handle(), overlayIndex, overlayValue, currentOverlayData.opacity);
-				ApplyHeadOverlayTint(ped, overlayIndex, colourType, currentOverlayData.colour = -1, currentOverlayData.colourSecondary = -1);
+				ApplyHeadOverlayTint(ped, overlayIndex, colourType, currentOverlayData.colour, currentOverlayData.colourSecondary);
 			}
 
 			if (overlayMinus)
@@ -1147,7 +1147,7 @@ namespace sub
 				}
 
 				SET_PED_HEAD_OVERLAY(ped.Handle(), overlayIndex, overlayValue, currentOverlayData.opacity);
-				ApplyHeadOverlayTint(ped, overlayIndex, colourType, currentOverlayData.colour = -1, currentOverlayData.colourSecondary = -1);
+				ApplyHeadOverlayTint(ped, overlayIndex, colourType, currentOverlayData.colour, currentOverlayData.colourSecondary);
 			}
 
 			// OPACITY


### PR DESCRIPTION
This PR fixes a bug (unless this behavior was deliberate for some reason?) that made ped overlay (makeup, beard, eyebrows etc.) color reset to -1 every time user changed the overlays' variation. 
Having to change the color every time that you wanted to preview a different beard or eyebrows was annoying and this commit makes Menyoo behave as it did before the changes introduced in https://github.com/itsjustcurtis/MenyooSP/commit/7147827eb62b750507b7b8b8c5c2b42ef496bb81.

This change was tested in-game and works fine; below are videos showcasing the before and after.

New behavior
https://streamable.com/c7zep0

Old behavior
https://streamable.com/6hodkm