### PR TITLE
feat: add "preview mode" for ped decals

### DIFF
--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -30,6 +30,7 @@
 #include "..\Util\ExePath.h"
 #include "..\Util\FileLogger.h"
 #include "..\Util\StringManip.h"
+#include "..\Util\keyboard.h"
 
 #include "..\Menu\FolderPreviewBmps.h"
 #include "..\Submenus\PedModelChanger.h"
@@ -584,6 +585,18 @@ namespace sub
 	{
 		std::map<Ped, std::vector<PedDecalValue>> vPedsAndDecals;
 
+		bool g_tattooPreviewMode = false;
+		const NamedPedDecal* g_previewTattoo = nullptr;
+
+		void ClearPreviewTattoo()
+		{
+			if (g_previewTattoo && DOES_ENTITY_EXIST(g_Ped1))
+			{
+				g_previewTattoo->Remove(g_Ped1);
+				g_previewTattoo = nullptr;
+			}
+		}
+
 		bool NamedPedDecal::IsOnPed(GTAentity ped) const
 		{
 			auto it = vPedsAndDecals.find(ped.Handle());
@@ -732,19 +745,65 @@ namespace sub
 		{
 			GTAentity ped = g_Ped1;
 
+			bool bShortcutDecalPreviewPressed = false;
+
+			if (Menu::OnSubBack == nullptr)
+			{
+				Menu::OnSubBack = []
+				{
+					PedDecals::ClearPreviewTattoo();
+				};
+			}
+
 			AddTitle(selectedZone->first);
 
 			for (const auto& decal : selectedZone->second)
 			{
+				bool isHovered = (*Menu::currentopATM == Menu::printingop + 1);
 				bool bDecalPressedApply = false, bDecalPressedRemove = false;
-				AddTickol(decal.caption, decal.IsOnPed(ped), bDecalPressedApply, bDecalPressedRemove, TICKOL::TATTOOTHING);
+				bool bIsOnPed = decal.IsOnPed(ped);
+
+				AddTickol(decal.caption, bIsOnPed, bDecalPressedApply, bDecalPressedRemove, TICKOL::TATTOOTHING);
+
+				if (g_tattooPreviewMode && isHovered)
+				{
+					
+					if (g_previewTattoo != &decal)
+					{
+						ClearPreviewTattoo();
+						if (!bIsOnPed) {
+							decal.Apply(ped);
+							g_previewTattoo = &decal;
+						}
+					}
+				}
+
 				if (bDecalPressedApply)
 				{
+					decal.Apply(ped);
+				
+				}
+				// permanently adding a decal while it's being previewed
+				else if (bDecalPressedRemove && g_previewTattoo == &decal)
+				{
+					ClearPreviewTattoo();
 					decal.Apply(ped);
 				}
 				else if (bDecalPressedRemove)
 				{
 					decal.Remove(ped);
+				}
+			}
+
+			Menu::add_IB(VirtualKey::B, g_tattooPreviewMode ? "Preview: ON " : "Preview: OFF ");
+			bShortcutDecalPreviewPressed = IsKeyJustUp(VirtualKey::B);
+			if (bShortcutDecalPreviewPressed)
+			{
+				g_tattooPreviewMode = !g_tattooPreviewMode;
+				
+				if (!g_tattooPreviewMode)
+				{
+					ClearPreviewTattoo();
 				}
 			}
 

--- a/Solution/source/Submenus/PedComponentChanger.h
+++ b/Solution/source/Submenus/PedComponentChanger.h
@@ -75,6 +75,9 @@ namespace sub
 		extern std::pair<std::string, std::map<std::string, std::vector<NamedPedDecal>>>* selectedType;
 		extern std::pair<std::string, std::vector<NamedPedDecal>>* selectedZone;
 
+		extern bool g_tattooPreviewMode;
+		extern const NamedPedDecal* g_previewTattoo;
+
 		void Sub_Decals_Types();
 		void Sub_Decals_Zones();
 		void Sub_Decals_InZone();


### PR DESCRIPTION
This PR introduces a "preview mode" for ped overlay decals (tattoos, hair tattoos etc.). When enabled, it allows you to scroll up or down to preview how a tattoo looks like on your character by temporarily applying it to the character and removing it when user changes menus or moves focus to another item. This removes the previous need to manually apply and then remove every tattoo every time that you wanted to find a tattoo that fits your character as it was kinda annoying.

This change was tested with MP Freemode models and SP protagonists and works fine, here's a video demonstrating the functionality. 
https://streamable.com/9i7kyb