### PR TITLE
feat: third parent mixing

### DIFF
--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -1296,10 +1296,12 @@ namespace sub
 			// Shape IDs
 			addBlendIdTexter("Shape Inherited From Father", blendData.shapeFirstID, true);
 			addBlendIdTexter("Shape Inherited From Mother", blendData.shapeSecondID, true);
+			addBlendIdTexter("Shape Inherited From Ancestor", blendData.shapeThirdID, true);
 
 			// Skin IDs
 			addBlendIdTexter("Tone Inherited From Father", blendData.skinFirstID, true);
 			addBlendIdTexter("Tone Inherited From Mother", blendData.skinSecondID, true);
+			addBlendIdTexter("Tone Inherited From Ancestor", blendData.skinThirdID, true);
 
 			// Mixes
 			AddBreak("---Adjustment---");
@@ -1317,6 +1319,7 @@ namespace sub
 
 			addMixSlider("Shape", blendData.shapeMix);
 			addMixSlider("Tone", blendData.skinMix);
+			addMixSlider("Ancestor (Shape & Tone)", blendData.thirdMix);
 		}
 	}
 

--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -1273,7 +1273,7 @@ namespace sub
 			GET_PED_HEAD_BLEND_DATA(ped.Handle(), (Any*)&blendData);
 			std::vector<std::string> idNames;
 			float maxMix = 1.0f;
-			float minMix = -1.0f;
+			float minMix = 0.0f;
 			float mixStep = 0.01f;
 
 			AddTitle("Shape & Skin Tone");


### PR DESCRIPTION
GTA and Menyoo unofficially support the "third parent" option when creating MP Freemode characters. The data is stored inside HeadBlendData as `shapeThirdID`,  `skinThirdID` and `thirdMix` and Menyoo loads and saves character .xml files with this data without any problem. This PR gives users a way to edit this data inside Menyoo, as the only way to do it before was by manually editing character .xml files inside a text editor and then loading them into Menyoo.

This PR also changes minMix from `-1.0` to `0.0`, as `0.0` is the lowest possible mix value as evidenced below - there's no difference between -1 and 0.

<img width="1600" height="4320" alt="minmix" src="https://github.com/user-attachments/assets/442c0dfd-e736-4b95-a05a-8c64a026bacb" />
