### PR TITLE
feat: added "eyes only" variations of "keep looking at" tasks

### DIFF
--- a/Solution/source/Submenus/Spooner/STSTask.cpp
+++ b/Solution/source/Submenus/Spooner/STSTask.cpp
@@ -43,6 +43,8 @@ namespace sub::Spooner
 		{ STSTaskType::FaceEntity,{ "Face Entity", EntityType::PED } },
 		{ STSTaskType::LookAtCoord,{ "Keep Looking At Position", EntityType::PED } },
 		{ STSTaskType::LookAtEntity,{ "Keep Looking At Entity", EntityType::PED } },
+		{ STSTaskType::LookAtCoordEyesOnly,{ "Keep Looking At Position (Eyes Only)", EntityType::PED } },
+		{ STSTaskType::LookAtEntityEyesOnly,{ "Keep Looking At Entity (Eyes Only)", EntityType::PED } },
 		{ STSTaskType::TeleportToCoord,{ "Teleport To Position", EntityType::ALL } },
 		{ STSTaskType::SeekCoverAtCoord,{ "Seek Cover At Position", EntityType::PED } },
 		//{ STSTaskType::SlideToCoord, {"Slide To Position", EntityType::PED }},

--- a/Solution/source/Submenus/Spooner/STSTask.h
+++ b/Solution/source/Submenus/Spooner/STSTask.h
@@ -84,7 +84,9 @@ namespace sub::Spooner
 		AimAtCoord = 49,
 		AimAtEntity = 50,
 		AddBlip = 51,
-		RemoveBlip = 52
+		RemoveBlip = 52,
+		LookAtCoordEyesOnly = 53,
+		LookAtEntityEyesOnly = 54
 	};
 
 	extern std::vector<std::pair<STSTaskType, std::pair<std::string, EntityType>>> vSTSTaskTypeNames;

--- a/Solution/source/Submenus/Spooner/STSTasks.cpp
+++ b/Solution/source/Submenus/Spooner/STSTasks.cpp
@@ -449,6 +449,90 @@ namespace sub::Spooner
 				this->targetEntity = u_e_Handle;
 		}
 
+		void LookAtCoordEyesOnly::GetXmlNodeTaskSpecific(pugi::xml_node& nodeTask) const
+		{
+			auto nodePos = nodeTask.append_child("Position");
+			nodePos.append_attribute("X") = this->coord.x;
+			nodePos.append_attribute("Y") = this->coord.y;
+			nodePos.append_attribute("Z") = this->coord.z;
+		}
+		void LookAtCoordEyesOnly::ImportXmlNodeTaskSpecific(pugi::xml_node& nodeTask)
+		{
+			auto nodePos = nodeTask.child("Position");
+			this->coord.x = nodePos.attribute("X").as_float();
+			this->coord.y = nodePos.attribute("Y").as_float();
+			this->coord.z = nodePos.attribute("Z").as_float();
+		}
+		void LookAtCoordEyesOnly::ImportTaskDataSpecific(STSTask* otherTsk)
+		{
+			auto otherTskT = otherTsk->GetTypeTask<STSTasks::LookAtCoordEyesOnly>();
+			this->coord = otherTskT->coord;
+		}
+		LookAtCoordEyesOnly::LookAtCoordEyesOnly()
+		{
+			this->type = STSTaskType::LookAtCoordEyesOnly;
+			this->submenu = Submenus::Sub_TaskSequence::LookAtCoordEyesOnly;
+			this->duration = 10000;
+			this->durationAfterLife = 0;
+			this->isLoopedTask = false;
+		}
+		void LookAtCoordEyesOnly::RunP(GTAped& ep)
+		{
+			TASK_LOOK_AT_COORD(ep.Handle(), this->coord.x, this->coord.y, this->coord.z, this->durationAfterLife > 0 ? -1 : this->duration, 8192, 2);
+		}
+		void LookAtCoordEyesOnly::EndP(GTAped& ep)
+		{
+			if (this->durationAfterLife == 0)
+			{
+				ep.Task().ClearLookAt();
+			}
+		}
+
+		void LookAtEntityEyesOnly::GetXmlNodeTaskSpecific(pugi::xml_node& nodeTask) const
+		{
+			auto targetHandle = this->targetEntity.GetHandle();
+			if (targetHandle == PLAYER_PED_ID())
+				nodeTask.append_child("TargetInitHandle").text() = "PLAYER";
+			else
+				nodeTask.append_child("TargetInitHandle").text() = targetHandle;
+		}
+		void LookAtEntityEyesOnly::ImportXmlNodeTaskSpecific(pugi::xml_node& nodeTask)
+		{
+			if (strcmp(nodeTask.child("TargetInitHandle").text().as_string(), "PLAYER") == 0)
+				this->targetEntity.Handle() = PLAYER_PED_ID();
+			else
+				this->targetEntity.Handle() = nodeTask.child("TargetInitHandle").text().as_int();
+		}
+		void LookAtEntityEyesOnly::ImportTaskDataSpecific(STSTask* otherTsk)
+		{
+			auto otherTskT = otherTsk->GetTypeTask<STSTasks::LookAtEntityEyesOnly>();
+			this->targetEntity = otherTskT->targetEntity;
+		}
+		LookAtEntityEyesOnly::LookAtEntityEyesOnly()
+		{
+			this->type = STSTaskType::LookAtEntityEyesOnly;
+			this->submenu = Submenus::Sub_TaskSequence::LookAtEntityEyesOnly;
+			this->duration = 10000;
+			this->durationAfterLife = 0;
+			this->isLoopedTask = false;
+		}
+		void LookAtEntityEyesOnly::RunP(GTAped& ep)
+		{
+			TASK_LOOK_AT_ENTITY(ep.Handle(), this->targetEntity.Handle(), this->durationAfterLife > 0 ? -1 : this->duration, 8192, 2);
+		}
+		void LookAtEntityEyesOnly::EndP(GTAped& ep)
+		{
+			if (this->durationAfterLife == 0)
+			{
+				ep.Task().ClearLookAt();
+			}
+		}
+		void LookAtEntityEyesOnly::LoadTargetingDressing(Entity u_initHandle, Entity u_e_Handle)
+		{
+			if (this->targetEntity == u_initHandle && this->targetEntity != PLAYER_PED_ID())
+				this->targetEntity = u_e_Handle;
+		}
+
 		void TeleportToCoord::GetXmlNodeTaskSpecific(pugi::xml_node& nodeTask) const
 		{
 			nodeTask.append_child("TakeVehicleToo").text() = this->takeVehicleToo;

--- a/Solution/source/Submenus/Spooner/STSTasks.h
+++ b/Solution/source/Submenus/Spooner/STSTasks.h
@@ -184,6 +184,33 @@ namespace sub::Spooner
 			void LoadTargetingDressing(Entity u_initHandle, Entity u_e_Handle) override;
 		};
 
+		class LookAtCoordEyesOnly final : public STSTask
+		{
+		private:
+			void GetXmlNodeTaskSpecific(pugi::xml_node& nodeTask) const override;
+			void ImportXmlNodeTaskSpecific(pugi::xml_node& nodeTask) override;
+			void ImportTaskDataSpecific(STSTask* otherTsk) override;
+		public:
+			Vector3 coord;
+			LookAtCoordEyesOnly();
+			void RunP(GTAped& ep) override;
+			void EndP(GTAped& ep) override;
+		};
+
+		class LookAtEntityEyesOnly final : public STSTask
+		{
+		private:
+			void GetXmlNodeTaskSpecific(pugi::xml_node& nodeTask) const override;
+			void ImportXmlNodeTaskSpecific(pugi::xml_node& nodeTask) override;
+			void ImportTaskDataSpecific(STSTask* otherTsk) override;
+		public:
+			GTAentity targetEntity;
+			LookAtEntityEyesOnly();
+			void RunP(GTAped& ep) override;
+			void EndP(GTAped& ep) override;
+			void LoadTargetingDressing(Entity u_initHandle, Entity u_e_Handle) override;
+		};
+
 		class TeleportToCoord final : public STSTask
 		{
 		private:

--- a/Solution/source/Submenus/Spooner/SpoonerTaskSequence.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerTaskSequence.cpp
@@ -96,6 +96,8 @@ namespace sub::Spooner
 		case STSTaskType::FaceEntity: tskPtr = (new STSTasks::FaceEntity); break;
 		case STSTaskType::LookAtCoord: tskPtr = (new STSTasks::LookAtCoord); break;
 		case STSTaskType::LookAtEntity: tskPtr = (new STSTasks::LookAtEntity); break;
+		case STSTaskType::LookAtCoordEyesOnly: tskPtr = (new STSTasks::LookAtCoordEyesOnly); break;
+		case STSTaskType::LookAtEntityEyesOnly: tskPtr = (new STSTasks::LookAtEntityEyesOnly); break;
 		case STSTaskType::TeleportToCoord: tskPtr = (new STSTasks::TeleportToCoord); break;
 		case STSTaskType::SeekCoverAtCoord: tskPtr = (new STSTasks::SeekCoverAtCoord); break;
 		case STSTaskType::SlideToCoord: tskPtr = (new STSTasks::SlideToCoord); break;

--- a/Solution/source/Submenus/Spooner/Submenus_TaskSequence.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus_TaskSequence.cpp
@@ -332,6 +332,18 @@ namespace sub::Spooner
 
 				PAtEntity(tskPtr->targetEntity);
 			}
+			void LookAtCoordEyesOnly()
+			{
+				auto tskPtr = _selectedSTST->GetTypeTask<STSTasks::LookAtCoordEyesOnly>();
+
+				PAtCoord(tskPtr->coord);
+			}
+			void LookAtEntityEyesOnly()
+			{
+				auto tskPtr = _selectedSTST->GetTypeTask<STSTasks::LookAtEntityEyesOnly>();
+
+				PAtEntity(tskPtr->targetEntity);
+			}
 			void TeleportToCoord()
 			{
 				auto tskPtr = _selectedSTST->GetTypeTask<STSTasks::TeleportToCoord>();

--- a/Solution/source/Submenus/Spooner/Submenus_TaskSequence.h
+++ b/Solution/source/Submenus/Spooner/Submenus_TaskSequence.h
@@ -33,6 +33,8 @@ namespace sub::Spooner
 			void FaceEntity();
 			void LookAtCoord();
 			void LookAtEntity();
+			void LookAtCoordEyesOnly();
+			void LookAtEntityEyesOnly();
 			void TeleportToCoord();
 			void SeekCoverAtCoord();
 			void SlideToCoord();


### PR DESCRIPTION
This PR adds two "new" tasks:
- Keep Looking At Position (Eyes Only)
- Keep Looking At Entity (Eyes Only)

They work just like their normal versions, but they call TASK_LOOK_AT_COORD with a special flag (8192) that makes only the characters' eyes move, instead of both head and eyes - useful for close-up shots of characters, because the head often moved in weird, unpredictable and unnatural ways. 