### PR TITLE
fix: incorrect condition for parent head index warning

### DIFF
--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -1480,7 +1480,7 @@ namespace sub
 					headBlend.skinMix = nodePedHeadBlend.child("ToneVal").text().as_float();
 					headBlend.thirdMix = nodePedHeadBlend.child("OverrideVal").text().as_float();
 					headBlend.isParent = nodePedHeadBlend.child("IsP").text().as_int();
-					if (!g_unlockMaxIDs && headBlend.shapeFirstID > 45 || headBlend.shapeSecondID > 45 || headBlend.shapeThirdID > 45)
+					if (!g_unlockMaxIDs && (headBlend.shapeFirstID > 45 || headBlend.shapeSecondID > 45 || headBlend.shapeThirdID > 45))
 					{
 						Game::Print::PrintBottomCentre("~r~Warning:~s~ Parent Head Index outside normal range. Ensure Addon Heads are installed and Max Head IDs are unlocked");
 						addlog(ige::LogType::LOG_WARNING, "Ped Head Index " + std::to_string(max(headBlend.shapeFirstID, max(headBlend.shapeSecondID, headBlend.shapeThirdID))) + " outside normal range of 0-45. Ensure Matching Addon Heads are installed from XML Source and Max Head IDs are unlocked.");


### PR DESCRIPTION
This PR fixes a warning that was displayed despite `g_unlockMaxIDs` being true while second and third shape were higher than 45, because the original condition was checking if:
- `!g_unlockMaxIDs && headBlend.shapeFirstID > 45`, or
- `headBlend.shapeSecondID > 45`, or
- `headBlend.shapeThirdID > 45`

It now checks if:
- `g_unlockMaxIDs` is false **and**
- any parent shape is higher than 45