### PR TITLE
refactor: XYZH, FPS and spooner overlays

### DIFF
--- a/Solution/source/Menu/Menu.cpp
+++ b/Solution/source/Menu/Menu.cpp
@@ -147,7 +147,7 @@ INT8 font_title = 7;
 INT8 font_options = 4;
 INT8 font_selection = 4;
 INT8 font_breaks = 1;
-INT8 font_xyzh = 0;
+INT8 font_hud = 0;
 INT8 font_speedo = 0;
 
 RGBA titlebox(0, 255, 255, 247);

--- a/Solution/source/Menu/Menu.h
+++ b/Solution/source/Menu/Menu.h
@@ -77,7 +77,7 @@ extern INT8 font_title;
 extern INT8 font_options;
 extern INT8 font_selection;
 extern INT8 font_breaks;
-extern INT8 font_xyzh;
+extern INT8 font_hud;
 extern INT8 font_speedo;
 
 extern RGBA titlebox;

--- a/Solution/source/Menu/MenuConfig.cpp
+++ b/Solution/source/Menu/MenuConfig.cpp
@@ -165,7 +165,8 @@ void MenuConfig::ConfigRead()
 	font_options = ini.GetLongValue(section_fonts.c_str(), "options", font_options);
 	font_selection = ini.GetLongValue(section_fonts.c_str(), "selection", font_selection);
 	font_breaks = ini.GetLongValue(section_fonts.c_str(), "breaks", font_breaks);
-	font_xyzh = ini.GetLongValue(section_fonts.c_str(), "font_xyzh", font_xyzh);
+	font_hud = ini.GetLongValue(section_fonts.c_str(), "font_xyzh", font_hud); // backwards compability, in newer versions font_xyzh has been renamed to font_hud
+	font_hud = ini.GetLongValue(section_fonts.c_str(), "font_hud", font_hud);
 	font_speedo = ini.GetLongValue(section_fonts.c_str(), "font_speedo", font_speedo);
 
 
@@ -199,7 +200,8 @@ void MenuConfig::ConfigRead()
 	showFullHUD = ini.GetBoolValue(section_haxValues.c_str(), "show_full_hud", showFullHUD);
 	ManualRespawn::g_manualRespawn.Enabled() = ini.GetBoolValue(section_haxValues.c_str(), "manual_respawn", ManualRespawn::g_manualRespawn.Enabled());
 	noClip = ini.GetBoolValue(section_haxValues.c_str(), "freecam", noClip);
-	xyzhCoords = ini.GetBoolValue(section_haxValues.c_str(), "display_xyzh_coords", xyzhCoords);
+	bDisplayXyzhCoords = ini.GetBoolValue(section_haxValues.c_str(), "display_xyzh_coords", bDisplayXyzhCoords);
+	sub::Spooner::Settings::bDisplaySpoonerInfo = ini.GetBoolValue(section_spooner.c_str(), "DisplaySpoonerInfo", sub::Spooner::Settings::bDisplaySpoonerInfo);
 	FPSCounter::bDisplayFps = ini.GetBoolValue(section_haxValues.c_str(), "display_fps", FPSCounter::bDisplayFps);
 	sub::TVChannelStuff::loopBasicTV = ini.GetBoolValue(section_haxValues.c_str(), "basic_tv_player", sub::TVChannelStuff::loopBasicTV);
 	syncClock = ini.GetBoolValue(section_haxValues.c_str(), "sync_clock", syncClock);
@@ -425,7 +427,7 @@ void MenuConfig::SaveConfig()
 	ini.SetLongValue(section_fonts.c_str(), "options", font_options);
 	ini.SetLongValue(section_fonts.c_str(), "selection", font_selection);
 	ini.SetLongValue(section_fonts.c_str(), "breaks", font_breaks);
-	ini.SetLongValue(section_fonts.c_str(), "font_xyzh", font_xyzh);
+	ini.SetLongValue(section_fonts.c_str(), "font_hud", font_hud);
 	ini.SetLongValue(section_fonts.c_str(), "font_speedo", font_speedo);
 
 
@@ -440,6 +442,7 @@ void MenuConfig::SaveConfig()
 	ini.SetDoubleValue(section_spooner.c_str(), "CameraRotationSensitivityGamepad", sub::Spooner::Settings::cameraRotationSensitivityGamepad);
 	ini.SetBoolValue(section_spooner.c_str(), "ShowModelPreviews", sub::Spooner::Settings::bShowModelPreviews);
 	ini.SetBoolValue(section_spooner.c_str(), "ShowBoxAroundSelectedEntity", sub::Spooner::Settings::bShowBoxAroundSelectedEntity);
+	ini.SetBoolValue(section_spooner.c_str(), "DisplaySpoonerInfo", sub::Spooner::Settings::bDisplaySpoonerInfo);
 	ini.SetBoolValue(section_spooner.c_str(), "SpawnDynamicProps", sub::Spooner::Settings::bSpawnDynamicProps);
 	ini.SetBoolValue(section_spooner.c_str(), "SpawnDynamicPeds", sub::Spooner::Settings::bSpawnDynamicPeds);
 	ini.SetBoolValue(section_spooner.c_str(), "SpawnDynamicVehicles", sub::Spooner::Settings::bSpawnDynamicVehicles);
@@ -459,7 +462,7 @@ void MenuConfig::SaveConfig()
 	ini.SetBoolValue(section_haxValues.c_str(), "show_full_hud", showFullHUD);
 	ini.SetBoolValue(section_haxValues.c_str(), "manual_respawn", ManualRespawn::g_manualRespawn.Enabled());
 	ini.SetBoolValue(section_haxValues.c_str(), "freecam", noClip);
-	ini.SetBoolValue(section_haxValues.c_str(), "display_xyzh_coords", xyzhCoords);
+	ini.SetBoolValue(section_haxValues.c_str(), "display_xyzh_coords", bDisplayXyzhCoords);
 	ini.SetBoolValue(section_haxValues.c_str(), "display_fps", FPSCounter::bDisplayFps);
 	ini.SetBoolValue(section_haxValues.c_str(), "basic_tv_player", sub::TVChannelStuff::loopBasicTV);
 	ini.SetBoolValue(section_haxValues.c_str(), "sync_clock", syncClock);

--- a/Solution/source/Menu/Routine.cpp
+++ b/Solution/source/Menu/Routine.cpp
@@ -616,7 +616,7 @@ bool playerInvincibility = false;
 bool noClip = false;
 bool noClipToggle = false; 
 bool superRun = false;
-bool xyzhCoords = false; 
+bool bDisplayXyzhCoords = false; 
 bool ignoredByEveryone = false; 
 bool neverWanted = false;
 bool superman = false;
@@ -2072,21 +2072,61 @@ void SetSelfRefillHealthWhenInCover()
 	}
 }
 
-void xyzhDrawFloat(float text, float x_coord, float y_coord)
+void DrawGameInfo()
 {
-	Game::Print::SetupDraw(font_xyzh, Vector2(0.35f, 0.35f), false, false, true);
-	Game::Print::drawfloat(text, 4, x_coord, y_coord);
-}
-void XYZH()
-{
-	Vector3 Pos = GET_ENTITY_COORDS(PLAYER_PED_ID(), 1);
+	constexpr float HUD_LINE_HEIGHT = 0.025f;
+	const Vector2 HUD_FONT_SIZE(0.35f, 0.35f);
 
-	Game::Print::SetupDraw(font_xyzh, Vector2(0.35f, 0.36f), false, false, true);
-	Game::Print::drawstring("Coords:", 0.94f, 0.03f);
-	xyzhDrawFloat(Pos.x, 0.94f, 0.06f);
-	xyzhDrawFloat(Pos.y, 0.94f, 0.09f);
-	xyzhDrawFloat(Pos.z, 0.94f, 0.12f);
-	xyzhDrawFloat(GET_ENTITY_HEADING(PLAYER_PED_ID()), 0.94f, 0.15f);
+	float hudY = 0.09f; // automatically increments with each drawn line
+
+	// automatically move the HUD to the left if menyoo menus are on the right to make sure that neither is obstructed
+	bool bRightJustified = get_xcoord_at_menu_leftEdge(0.0f, false) < 0.5f;
+	float hudX = bRightJustified ? 0.98f : 0.02f;
+	Vector2 hudTextWrap = bRightJustified ? Vector2(0.0f, 0.98f) : Vector2(0.0f, 1.0f);
+
+
+	auto drawText = [&](const std::string& text, RGBA colour = {255, 255, 255, 255})
+	{
+		Game::Print::SetupDraw(font_hud, HUD_FONT_SIZE, false, bRightJustified, true, colour, hudTextWrap);
+		Game::Print::drawstring(text, hudX, hudY);
+		hudY += HUD_LINE_HEIGHT;
+	};
+
+	auto drawFloat = [&](float value, UINT8 decimals, RGBA colour = {255, 255, 255, 255})
+	{
+		Game::Print::SetupDraw(font_hud, HUD_FONT_SIZE, false, bRightJustified, true, colour, hudTextWrap);
+		Game::Print::drawfloat(value, decimals, hudX, hudY);
+		hudY += HUD_LINE_HEIGHT;
+	};
+
+	if (FPSCounter::bDisplayFps)
+	{
+		auto fps = FPSCounter::g_fpsCounter.Get();
+		drawText(std::to_string(fps) + " FPS");
+		hudY += HUD_LINE_HEIGHT/2; // for visual separation between hud elements
+	}
+
+	if (bDisplayXyzhCoords)
+	{
+		Vector3 pos = GET_ENTITY_COORDS(PLAYER_PED_ID(), 1);
+		float heading = GET_ENTITY_HEADING(PLAYER_PED_ID());
+		drawText("Coords:");
+		drawFloat(pos.x, 4);
+		drawFloat(pos.y, 4);
+		drawFloat(pos.z, 4);
+		drawFloat(heading, 4);
+		hudY += HUD_LINE_HEIGHT/2; // for visual separation between hud elements
+	}
+
+	if (sub::Spooner::SpoonerMode::bEnabled)
+	{
+		auto stats = sub::Spooner::SpoonerMode::GetSpoonerStats();
+		drawText("Total Entities Spawned: " + std::to_string(stats.totalNumEntities));
+		drawText("Objects Spawned: " + std::to_string(stats.totalNumProps));
+		drawText("Peds Spawned: " + std::to_string(stats.totalNumPeds));
+		drawText("Vehicles Spawned: " + std::to_string(stats.totalNumVehicles));
+		hudY += HUD_LINE_HEIGHT/2; // for visual separation between hud elements
+	}
 }
 
 void SetLocalSupermanManual()
@@ -3874,14 +3914,7 @@ void Menu::loops()
 	TickPlayerAbilities();
 
 	// HUD overlays
-	if (xyzhCoords)
-	{
-		XYZH();
-	}
-	if (FPSCounter::bDisplayFps)
-	{
-		FPSCounter::DisplayFps();
-	}
+	DrawGameInfo();
 
 	TickVehicleEffects(gameIsPaused);
 	SetPVOpsVehicleTextWorld2Screen();

--- a/Solution/source/Menu/Routine.cpp
+++ b/Solution/source/Menu/Routine.cpp
@@ -2118,7 +2118,7 @@ void DrawGameInfo()
 		hudY += HUD_LINE_HEIGHT/2; // for visual separation between hud elements
 	}
 
-	if (sub::Spooner::SpoonerMode::bEnabled)
+	if (sub::Spooner::SpoonerMode::bEnabled && sub::Spooner::Settings::bDisplaySpoonerInfo)
 	{
 		auto stats = sub::Spooner::SpoonerMode::GetSpoonerStats();
 		drawText("Total Entities Spawned: " + std::to_string(stats.totalNumEntities));

--- a/Solution/source/Menu/Routine.h
+++ b/Solution/source/Menu/Routine.h
@@ -183,7 +183,7 @@ extern bool playerInvincibility;
 extern bool noClip;
 extern bool noClipToggle;
 extern bool superRun;
-extern bool xyzhCoords;
+extern bool bDisplayXyzhCoords;
 extern bool ignoredByEveryone;
 extern bool neverWanted;
 extern bool superman;

--- a/Solution/source/Misc/FpsCounter.cpp
+++ b/Solution/source/Misc/FpsCounter.cpp
@@ -16,7 +16,6 @@
 #include "..\Util\GTAmath.h"
 
 #include <Windows.h> // GetTickCount
-#include <string>
 
 namespace FPSCounter
 {
@@ -25,14 +24,10 @@ namespace FPSCounter
 	{
 	}
 
-	DWORD FpsCounter::Get() const
+	DWORD FpsCounter::Get()
 	{
+		this->Tick();
 		return fpsValue;
-	}
-
-	std::string FpsCounter::GetString() const
-	{
-		return std::to_string(fpsValue);
 	}
 
 	void FpsCounter::Tick()
@@ -51,18 +46,6 @@ namespace FPSCounter
 	}
 
 	FpsCounter g_fpsCounter;
-
-	void DisplayFps()
-	{
-		g_fpsCounter.Tick();
-		Game::Print::SetupDraw(GTAfont::Impact, Vector2(0.4f, 0.4f), false, false, false);
-		Game::Print::drawstring("~y~" + g_fpsCounter.GetString() + " FPS", 0.965f, 0.008f);
-	}
-
-	void DisplayFpsTick()
-	{
-
-	}
 
 	bool bDisplayFps = false;
 }

--- a/Solution/source/Misc/FpsCounter.h
+++ b/Solution/source/Misc/FpsCounter.h
@@ -9,8 +9,6 @@
 */
 #pragma once
 
-#include <string>
-
 typedef unsigned long DWORD;
 
 namespace FPSCounter
@@ -25,18 +23,11 @@ namespace FPSCounter
 	public:
 		FpsCounter();
 
-		DWORD Get() const;
-
-		std::string GetString() const;
+		DWORD Get();
 
 		void Tick();
 	};
-	extern FpsCounter g_fpsCounter;
-
-
-	void DisplayFps();
-
-	void DisplayFpsTick();
+extern FpsCounter g_fpsCounter;
 
 	extern bool bDisplayFps;
 }

--- a/Solution/source/Submenus/MiscOptions.cpp
+++ b/Solution/source/Submenus/MiscOptions.cpp
@@ -868,7 +868,7 @@ namespace sub
 				SET_MINIMAP_HIDE_FOW(revealMinimap);
 			}
 
-			AddToggle("Display XYZH Coords", xyzhCoords);
+			AddToggle("Display XYZH Coords", bDisplayXyzhCoords);
 			AddToggle("Display FPS", FPSCounter::bDisplayFps);
 			AddToggle("Hide HUD", hideHUD);
 			AddToggle("Show Full HUD", showFullHUD);

--- a/Solution/source/Submenus/Settings.cpp
+++ b/Solution/source/Submenus/Settings.cpp
@@ -292,7 +292,7 @@ namespace sub
 		AddsettingsfonOption("Options", -1, font_options);
 		AddsettingsfonOption("Selected Option", -1, font_selection);
 		AddsettingsfonOption("Option Breaks", -1, font_breaks);
-		AddsettingsfonOption("XYZH Coords", -1, font_xyzh);
+		AddsettingsfonOption("HUD Font", -1, font_hud);
 		AddsettingsfonOption("Speedo Text", -1, font_speedo);
 	}
 	
@@ -365,7 +365,7 @@ namespace sub
 		INT8 f_options;
 		INT8 f_selection;
 		INT8 f_breaks;
-		INT8 f_xyzh;
+		INT8 f_hud;
 		INT8 f_speedo;
 	public:
 		MenyooTheme()
@@ -373,7 +373,7 @@ namespace sub
 		}
 		MenyooTheme(bool _grads, bool _rainbow, bool _thinLineOverFooter,
 			RGBA _ttbox, RGBA _bgbox, RGBA _tttext, RGBA _optext, RGBA _seltext, RGBA _opbreak, RGBA _opcount, RGBA _selhi, RGBA _pedtrackers,
-			INT8 _f_title, INT8 _f_options, INT8 _f_selection, INT8 _f_breaks, INT8 _f_xyzh, INT8 _f_speedo)
+			INT8 _f_title, INT8 _f_options, INT8 _f_selection, INT8 _f_breaks, INT8 _f_hud, INT8 _f_speedo)
 		{
 			grads = _grads;
 			rainbow = _rainbow;
@@ -393,7 +393,7 @@ namespace sub
 			f_options = _f_options;
 			f_selection = _f_selection;
 			f_breaks = _f_breaks;
-			f_xyzh = _f_xyzh;
+			f_hud = _f_hud;
 			f_speedo = _f_speedo;
 		}
 
@@ -417,7 +417,7 @@ namespace sub
 			font_options = f_options;
 			font_selection = f_selection;
 			font_breaks = f_breaks;
-			font_xyzh = f_xyzh;
+			font_hud = f_hud;
 			font_speedo = f_speedo;
 		}
 		bool IsActive()
@@ -441,7 +441,7 @@ namespace sub
 				font_options == f_options &&
 				font_selection == f_selection &&
 				font_breaks == f_breaks &&
-				font_xyzh == f_xyzh &&
+				font_hud == f_hud &&
 				font_speedo == f_speedo;
 		}
 
@@ -467,7 +467,7 @@ namespace sub
 			curr.f_options = font_options;
 			curr.f_selection = font_selection;
 			curr.f_breaks = font_breaks;
-			curr.f_xyzh = font_xyzh;
+			curr.f_hud = font_hud;
 			curr.f_speedo = font_speedo;
 
 			return curr;
@@ -496,7 +496,7 @@ namespace sub
 				value1.f_options == value2.f_options &&
 				value1.f_selection == value2.f_selection &&
 				value1.f_breaks == value2.f_breaks &&
-				value1.f_xyzh == value2.f_xyzh &&
+				value1.f_hud == value2.f_hud &&
 				value1.f_speedo == value2.f_speedo;
 		}
 		bool Equals(MenyooTheme const& value2)

--- a/Solution/source/Submenus/Spooner/SpoonerMode.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.cpp
@@ -58,6 +58,22 @@ namespace sub::Spooner
 		float spoonerModeCameraCamDistance = 5.0f;
 		eSpoonerModeMode& spoonerModeMode = Settings::spoonerModeMode;
 
+		SpoonerStats GetSpoonerStats()
+		{
+			SpoonerStats stats = { 0, 0, 0, 0 };
+			stats.totalNumEntities = (UINT)Databases::EntityDb.size();
+			for (auto& spoonerEntity : Databases::EntityDb)
+			{
+				switch (spoonerEntity.type)
+				{
+				case EntityType::PROP: stats.totalNumProps++; break;
+				case EntityType::PED: stats.totalNumPeds++; break;
+				case EntityType::VEHICLE: stats.totalNumVehicles++; break;
+				}
+			}
+			return stats;
+		}
+
 		bool IsHotkeyPressed()
 		{
 			if (std::find(std::begin(Menu::currentArray), std::end(Menu::currentArray), SUB::SPOONER_MAIN) == std::end(Menu::currentArray))
@@ -253,32 +269,6 @@ namespace sub::Spooner
 			if (SpoonerMode::bEnabled)
 			{
 				HIDE_HUD_AND_RADAR_THIS_FRAME();
-
-				//if (setting)
-				{
-					UINT totalNumProps = 0, totalNumPeds = 0, totalNumVehicles = 0;
-					UINT totalNumEntities = (UINT)Databases::EntityDb.size();
-					for (auto& eee : Databases::EntityDb)
-					{
-						switch (eee.type)
-						{
-						case EntityType::PROP: totalNumProps++; break;
-						case EntityType::PED: totalNumPeds++; break;
-						case EntityType::VEHICLE: totalNumVehicles++; break;
-						}
-					}
-					bool bRightJus = get_xcoord_at_menu_leftEdge(0.0f, false) < 0.5f; // left edge of menu is on the left of the centre of the screen
-					float infoX = bRightJus ? 0.90f : 0.008f;
-					float infoY = xyzhCoords ? 0.184f : 0.064f;
-					Game::Print::SetupDraw(font_xyzh, Vector2(0.37f, 0.37f), false, bRightJus, true);
-					Game::Print::drawstring("Total Entities Spawned: " + std::to_string(totalNumEntities), infoX, infoY);
-					Game::Print::SetupDraw(font_xyzh, Vector2(0.37f, 0.37f), false, bRightJus, true);
-					Game::Print::drawstring("Objects Spawned: " + std::to_string(totalNumProps), infoX, infoY + 0.03f);
-					Game::Print::SetupDraw(font_xyzh, Vector2(0.37f, 0.37f), false, bRightJus, true);
-					Game::Print::drawstring("Peds Spawned: " + std::to_string(totalNumPeds), infoX, infoY + 0.06f);
-					Game::Print::SetupDraw(font_xyzh, Vector2(0.37f, 0.37f), false, bRightJus, true);
-					Game::Print::drawstring("Vehicles Spawned: " + std::to_string(totalNumVehicles), infoX, infoY + 0.09f);
-				}
 
 				if (!freeCam.Exists())
 				{

--- a/Solution/source/Submenus/Spooner/SpoonerMode.h
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.h
@@ -35,6 +35,14 @@ namespace sub::Spooner
 		extern Camera spoonerModeCamera;
 		extern float spoonerModeCameraCamDistance;
 
+		struct SpoonerStats {
+			int totalNumEntities;
+			int totalNumProps;
+			int totalNumPeds;
+			int totalNumVehicles;
+		};
+		SpoonerStats GetSpoonerStats();
+
 		bool IsHotkeyPressed();
 
 		struct ModelPreviewInfoStructure

--- a/Solution/source/Submenus/Spooner/SpoonerSettings.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerSettings.cpp
@@ -36,6 +36,7 @@ namespace sub::Spooner
 		eSpoonerModeMode spoonerModeMode = eSpoonerModeMode::GroundEase;
 
 		bool bShowModelPreviews = true;
+		bool bDisplaySpoonerInfo = true;
 		bool bShowBoxAroundSelectedEntity = false;
 		bool bSpawnDynamicProps = false;
 		bool bSpawnDynamicPeds = true;
@@ -45,7 +46,7 @@ namespace sub::Spooner
 		bool bSpawnStillPeds = true;
 		bool bAddToDbAsMissionEntities = true;
 		bool bKeepPositionWhenAttaching = false;
-
+		
 		bool bTeleportToReferenceWhenLoadingFile = true;
 	}
 

--- a/Solution/source/Submenus/Spooner/SpoonerSettings.h
+++ b/Solution/source/Submenus/Spooner/SpoonerSettings.h
@@ -31,6 +31,7 @@ namespace sub::Spooner
 		extern eSpoonerModeMode spoonerModeMode;
 
 		extern bool bShowModelPreviews;
+		extern bool bDisplaySpoonerInfo;
 		extern bool bShowBoxAroundSelectedEntity;
 		extern bool bSpawnDynamicProps;
 		extern bool bSpawnDynamicPeds;

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -104,6 +104,7 @@ namespace sub
 
 			AddTitle("Settings");
 			AddToggle("Display Model Previews (Spooner Mode)", Settings::bShowModelPreviews);
+			AddToggle("Display Spooner Info", Settings::bDisplaySpoonerInfo);
 			AddToggle("Display Entity Surrounding Box", Settings::bShowBoxAroundSelectedEntity);
 			AddToggle("Spawn Dynamic Objects", Settings::bSpawnDynamicProps);
 			AddToggle("Spawn Dynamic Peds", Settings::bSpawnDynamicPeds);

--- a/Solution/source/_Build/bin/Release/menyooStuff/menyooConfig.ini
+++ b/Solution/source/_Build/bin/Release/menyooStuff/menyooConfig.ini
@@ -264,6 +264,6 @@ title = 7
 options = 4
 selection = 4
 breaks = 1
-font_xyzh = 0
+font_hud = 0
 font_speedo = 7
 font_whostalking = 0

--- a/Solution/source/_Build/bin/Release/menyooStuff/menyooConfig.ini
+++ b/Solution/source/_Build/bin/Release/menyooStuff/menyooConfig.ini
@@ -153,6 +153,7 @@ CameraRotationSensitivityMouse = 11.0
 CameraMovementSensitivityGamepad = 0.9
 CameraRotationSensitivityGamepad = 2.5
 ShowModelPreviews = 1
+DisplaySpoonerInfo = true
 ShowBoxAroundSelectedEntity = 0
 SpawnDynamicProps = 0
 SpawnDynamicPeds = 1


### PR DESCRIPTION
This PR refactors drawing the info HUD (FPS, coords, spooner info) to help with issues #533 and #530. Menyoo will now draw all these elements inside a single function and automatically make sure that they don't overlay each other - and as a bonus it will be easier to add new elements to the HUD. 
While working on the HUD i have also refactored a few variable names for better consistency and to make it more obvious what they are used for.

I have also added a new settings option `bDisplaySpoonerInfo` that I guess was planned, but never really implemented basing on this commented out `if` from SpoonerMode.cpp that was used for displaying Spooner info. 
```
//if (setting)
				{
					UINT totalNumProps = 0, totalNumPeds = 0, totalNumVehicles = 0;
					...
```

It basically controls whether to draw the spooner ped, object and vehicle info and will be enabled by default to make it consistent with pre-update behavior; users can just disable it if they want.

Preview video: https://streamable.com/un614l
