### PR TITLE
feat: keyboard entity movement mode for Manual Placement / Attachment Options

### DIFF
--- a/Solution/source/Submenus/PedAnimation.cpp
+++ b/Solution/source/Submenus/PedAnimation.cpp
@@ -602,6 +602,8 @@ namespace sub
 				g_customAnimDuration -= 100;
 				return;
 			}
+		}
+		if (flagPlus) {
 			for (auto it = AnimFlag::vFlagNames.begin(); it != AnimFlag::vFlagNames.end(); ++it)
 			{
 				if (it->first == g_customAnimFlag)

--- a/Solution/source/Submenus/Spooner/SpoonerMode.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.cpp
@@ -54,6 +54,8 @@ namespace sub::Spooner
 		bool bEnabled = false;
 		bool bIsSomethingHeld = false;
 		bool bHeldEntityHasCollision = true;
+		bool bKeyboardEntityEditingEnabled = false;
+		bool bKeyboardEntityEditingRotationMode = false;
 		Camera spoonerModeCamera;
 		float spoonerModeCameraCamDistance = 5.0f;
 		eSpoonerModeMode& spoonerModeMode = Settings::spoonerModeMode;
@@ -585,10 +587,14 @@ namespace sub::Spooner
 					float movementSensitivity = Settings::cameraMovementSensitivityKeyboard;
 					if (IS_DISABLED_CONTROL_PRESSED(0, INPUT_SPRINT))
 						movementSensitivity = 4.0f * movementSensitivity;
-
-					nextOffset.x = GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_LR) * movementSensitivity;
-					nextOffset.y = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_UD) * movementSensitivity;
-					nextOffset.z = IsKeyDown(VirtualKey::X) ? movementSensitivity / 2 : IsKeyDown(VirtualKey::Z) ? -movementSensitivity / 2 : 0.0f;
+					
+					// blocks camera movements while we are using the keyboard to edit entity pos / rot using the keyboard
+					if (!bKeyboardEntityEditingEnabled)  
+					{
+						nextOffset.x = GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_LR) * movementSensitivity;
+						nextOffset.y = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_UD) * movementSensitivity;
+						nextOffset.z = IsKeyDown(VirtualKey::X) ? movementSensitivity / 2 : IsKeyDown(VirtualKey::Z) ? -movementSensitivity / 2 : 0.0f;
+					}
 
 					float rotationSensitivity = Settings::cameraRotationSensitivityMouse;
 					nextRot.z = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_LOOK_LR) * rotationSensitivity;
@@ -937,6 +943,3 @@ namespace sub::Spooner
 	}
 
 }
-
-
-

--- a/Solution/source/Submenus/Spooner/SpoonerMode.h
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.h
@@ -32,6 +32,8 @@ namespace sub::Spooner
 		extern bool bEnabled;
 		extern bool bIsSomethingHeld;
 		extern bool bHeldEntityHasCollision;
+		extern bool bKeyboardEntityEditingEnabled;
+		extern bool bKeyboardEntityEditingRotationMode;
 		extern Camera spoonerModeCamera;
 		extern float spoonerModeCameraCamDistance;
 
@@ -62,6 +64,3 @@ namespace sub::Spooner
 	}
 
 }
-
-
-

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -77,8 +77,89 @@ namespace sub
 		void SetEnt241() { g_Ped1 = selectedEntity.handle.Handle(); }
 		void SetEnt12() { g_Ped4 = selectedEntity.handle.Handle(); }
 
-		void Sub_SpoonerMain()
+		void HandleKeyboardPlacementInput(Vector3& position, Vector3& rotation)
 		{
+			// toggling the keyboard controls on and off
+			static bool lastBToggle = false;
+			bool currentBToggle = IsKeyJustUp(VirtualKey::B);
+			if (currentBToggle && !lastBToggle)
+			{
+				SpoonerMode::bKeyboardEntityEditingEnabled = !SpoonerMode::bKeyboardEntityEditingEnabled;
+			}
+			lastBToggle = currentBToggle;
+			
+			// toggling between the rotation / position modes
+			static bool lastRToggle = false;
+			bool currentRToggle = IsKeyJustUp(VirtualKey::R);
+			if (currentRToggle && !lastRToggle)
+			{
+				SpoonerMode::bKeyboardEntityEditingRotationMode = !SpoonerMode::bKeyboardEntityEditingRotationMode;
+			}
+			lastRToggle = currentRToggle;
+
+			// text drawing variables
+			constexpr float HUD_LINE_HEIGHT = 0.025f;
+			const Vector2 HUD_FONT_SIZE(0.35f, 0.35f);
+			const float hudX = 0.02f;
+			float hudY = 0.8f;
+
+			auto drawText = [&](const std::string& text, RGBA colour = {255, 255, 255, 255})
+			{
+				Game::Print::SetupDraw(GTAfont::Arial, HUD_FONT_SIZE, false, false, true, colour);
+				Game::Print::drawstring(text, hudX, hudY);
+				hudY += HUD_LINE_HEIGHT;
+			};
+
+			if (!SpoonerMode::bKeyboardEntityEditingEnabled)
+			{
+				drawText("~r~Keyboard controls DISABLED.");
+				drawText("~r~You can click B to use your keyboard to position and rotate the entity.");
+				return;
+			}
+
+			if(SpoonerMode::bKeyboardEntityEditingRotationMode) 
+			{
+				drawText("~y~Rotation Mode:");
+				drawText("~b~W/S: ~w~Pitch+ / Pitch-");
+				drawText("~b~A/D: ~w~Yaw+ / Yaw-");
+				drawText("~b~E/Q: ~w~Roll+ / Roll-");
+				drawText("~b~=/-: ~w~+/- Sensitivity");
+				drawText("~b~R: ~w~Toggle position");
+			} else 
+			{
+				drawText("~y~Position Mode:");
+				drawText("~b~W/S: ~w~X+ / X-");
+				drawText("~b~A/D: ~w~Y+ / Y-");
+				drawText("~b~E/Q: ~w~Z+ / Z-");
+				drawText("~b~=/-: ~w~+/- Sensitivity");
+				drawText("~b~R: ~w~Toggle rotation");
+			}
+			drawText("~b~B: ~w~Unlock camera and disable keyboard controls.");
+
+			static DWORD lastSensitivityChange = 0;
+			if (IsKeyJustUp(VirtualKey::OEMPlus) && GetTickCount() - lastSensitivityChange > 200)
+			{
+				if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10;
+				lastSensitivityChange = GetTickCount();
+			}
+			if (IsKeyJustUp(VirtualKey::OEMMinus) && GetTickCount() - lastSensitivityChange > 200)
+			{
+				if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10;
+				lastSensitivityChange = GetTickCount();
+			}
+
+			auto& target = SpoonerMode::bKeyboardEntityEditingRotationMode ? rotation : position;
+			if (IsKeyDown(VirtualKey::W)) target.x += _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::S)) target.x -= _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::A)) target.y += _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::D)) target.y -= _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::E)) target.z += _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::Q)) target.z -= _manualPlacementPrecision;
+		}
+
+	void Sub_SpoonerMain()
+		{
+			SpoonerMode::bKeyboardEntityEditingEnabled = false;
 			selectedEntity.handle = 0;
 			_searchStr.clear(); // Sub_SaveFiles _searchStr
 			dict3.clear(); // Sub_SaveFiles _dir
@@ -1038,6 +1119,7 @@ namespace sub
 		}*/
 		void Sub_SelectedEntityOps()
 		{
+			SpoonerMode::bKeyboardEntityEditingEnabled = false;
 			if (!selectedEntity.handle.Exists())
 			{
 				Menu::SetPreviousMenu();
@@ -1377,6 +1459,8 @@ namespace sub
 				Vector3 nextOffset = selectedEntity.attachmentArgs.offset;
 				Vector3 nextRot = selectedEntity.attachmentArgs.rotation;
 
+				HandleKeyboardPlacementInput(nextOffset, nextRot);
+
 				// Bone text scroller if type is PED or VEHICLE. Reattach and reset args on bone change.
 				if (baseEntityType == EntityType::PED)
 				{
@@ -1503,12 +1587,16 @@ namespace sub
 				if (z_plus) nextOffset.z += _manualPlacementPrecision;
 				if (z_minus) nextOffset.z -= _manualPlacementPrecision;
 
-				if (pitch_plus) { nextRot.x += _manualPlacementPrecision; if (nextRot.x > 180.0f) nextRot.x -= 360.0f; }
-				if (pitch_minus) { nextRot.x -= _manualPlacementPrecision; if (nextRot.x < -180.0f) nextRot.x += 360.0f; }
-				if (roll_plus) { nextRot.y += _manualPlacementPrecision; if (nextRot.y > 180.0f) nextRot.y -= 360.0f; }
-				if (roll_minus) { nextRot.y -= _manualPlacementPrecision; if (nextRot.y < -180.0f) nextRot.y += 360.0f; }
-				if (yaw_plus) { nextRot.z += _manualPlacementPrecision; if (nextRot.z > 180.0f) nextRot.z -= 360.0f; }
-				if (yaw_minus) { nextRot.z -= _manualPlacementPrecision; if (nextRot.z < -180.0f) nextRot.z += 360.0f; }
+				if (pitch_plus) nextRot.x += _manualPlacementPrecision;
+				if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
+				if (roll_plus) nextRot.y += _manualPlacementPrecision;
+				if (roll_minus) nextRot.y -= _manualPlacementPrecision;
+				if (yaw_plus) nextRot.z += _manualPlacementPrecision;
+				if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+				WrapAngle(nextRot.x);
+				WrapAngle(nextRot.y);
+				WrapAngle(nextRot.z);
 
 				if (nextOffset != selectedEntity.attachmentArgs.offset || nextRot != selectedEntity.attachmentArgs.rotation || nextBoneIndex != selectedEntity.attachmentArgs.boneIndex)
 				{
@@ -1719,6 +1807,8 @@ namespace sub
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
+			HandleKeyboardPlacementInput(nextPos, nextRot);
+
 			if (x_plus) nextPos.x += _manualPlacementPrecision;
 			if (x_minus) nextPos.x -= _manualPlacementPrecision;
 			if (y_plus) nextPos.y += _manualPlacementPrecision;
@@ -1726,12 +1816,16 @@ namespace sub
 			if (z_plus) nextPos.z += _manualPlacementPrecision;
 			if (z_minus) nextPos.z -= _manualPlacementPrecision;
 
-			if (pitch_plus) { nextRot.x += _manualPlacementPrecision; if (nextRot.x > 180.0f) nextRot.x -= 360.0f; }
-			if (pitch_minus) { nextRot.x -= _manualPlacementPrecision; if (nextRot.x < -180.0f) nextRot.x += 360.0f; }
-			if (roll_plus) { nextRot.y += _manualPlacementPrecision; if (nextRot.y > 180.0f) nextRot.y -= 360.0f; }
-			if (roll_minus) { nextRot.y -= _manualPlacementPrecision; if (nextRot.y < -180.0f) nextRot.y += 360.0f; }
-			if (yaw_plus) { nextRot.z += _manualPlacementPrecision; if (nextRot.z > 180.0f) nextRot.z -= 360.0f; }
-			if (yaw_minus) { nextRot.z -= _manualPlacementPrecision; if (nextRot.z < -180.0f) nextRot.z += 360.0f; }
+			if (pitch_plus) nextRot.x += _manualPlacementPrecision;
+			if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
+			if (roll_plus) nextRot.y += _manualPlacementPrecision;
+			if (roll_minus) nextRot.y -= _manualPlacementPrecision;
+			if (yaw_plus) nextRot.z += _manualPlacementPrecision;
+			if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+			WrapAngle(nextRot.x);
+			WrapAngle(nextRot.y);
+			WrapAngle(nextRot.z);
 
 			if (nextPos != currPos)
 			{
@@ -1898,6 +1992,8 @@ namespace sub
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
+			HandleKeyboardPlacementInput(nextPos, nextRot);
+
 			if (x_plus) nextPos.x += _manualPlacementPrecision;
 			if (x_minus) nextPos.x -= _manualPlacementPrecision;
 			if (y_plus) nextPos.y += _manualPlacementPrecision;
@@ -1905,12 +2001,16 @@ namespace sub
 			if (z_plus) nextPos.z += _manualPlacementPrecision;
 			if (z_minus) nextPos.z -= _manualPlacementPrecision;
 
-			if (pitch_plus) { nextRot.x += _manualPlacementPrecision; if (nextRot.x > 180.0f) nextRot.x -= 360.0f; }
-			if (pitch_minus) { nextRot.x -= _manualPlacementPrecision; if (nextRot.x < -180.0f) nextRot.x += 360.0f; }
-			if (roll_plus) { nextRot.y += _manualPlacementPrecision; if (nextRot.y > 180.0f) nextRot.y -= 360.0f; }
-			if (roll_minus) { nextRot.y -= _manualPlacementPrecision; if (nextRot.y < -180.0f) nextRot.y += 360.0f; }
-			if (yaw_plus) { nextRot.z += _manualPlacementPrecision; if (nextRot.z > 180.0f) nextRot.z -= 360.0f; }
-			if (yaw_minus) { nextRot.z -= _manualPlacementPrecision; if (nextRot.z < -180.0f) nextRot.z += 360.0f; }
+			if (pitch_plus) nextRot.x += _manualPlacementPrecision;
+			if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
+			if (roll_plus) nextRot.y += _manualPlacementPrecision;
+			if (roll_minus) nextRot.y -= _manualPlacementPrecision;
+			if (yaw_plus) nextRot.z += _manualPlacementPrecision;
+			if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+			WrapAngle(nextRot.x);
+			WrapAngle(nextRot.y);
+			WrapAngle(nextRot.z);
 
 			if (nextPos != currPos) selectedEntity.handle.SetPosition(nextPos);
 			if (nextRot != currRot) selectedEntity.handle.SetRotation(nextRot);
@@ -1968,12 +2068,17 @@ namespace sub
 				AddNumber("Pitch", currRot.x, 4, null, pitch_plus, pitch_minus);
 				AddNumber("Roll", currRot.y, 4, null, roll_plus, roll_minus);
 				AddNumber("Yaw", currRot.z, 4, null, yaw_plus, yaw_minus);
-				if (pitch_plus) { nextRot.x += _manualPlacementPrecision; if (nextRot.x > 180.0f) nextRot.x -= 360.0f; }
-				if (pitch_minus) { nextRot.x -= _manualPlacementPrecision; if (nextRot.x < -180.0f) nextRot.x += 360.0f; }
-				if (roll_plus) { nextRot.y += _manualPlacementPrecision; if (nextRot.y > 180.0f) nextRot.y -= 360.0f; }
-				if (roll_minus) { nextRot.y -= _manualPlacementPrecision; if (nextRot.y < -180.0f) nextRot.y += 360.0f; }
-				if (yaw_plus) { nextRot.z += _manualPlacementPrecision; if (nextRot.z > 180.0f) nextRot.z -= 360.0f; }
-				if (yaw_minus) { nextRot.z -= _manualPlacementPrecision; if (nextRot.z < -180.0f) nextRot.z += 360.0f; }
+				
+				if (pitch_plus) nextRot.x += _manualPlacementPrecision;
+				if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
+				if (roll_plus) nextRot.y += _manualPlacementPrecision;
+				if (roll_minus) nextRot.y -= _manualPlacementPrecision;
+				if (yaw_plus) nextRot.z += _manualPlacementPrecision;
+				if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+				WrapAngle(nextRot.x);
+				WrapAngle(nextRot.y);
+				WrapAngle(nextRot.z);
 			}
 
 		}
@@ -2034,6 +2139,8 @@ namespace sub
 				if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 				if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
+				HandleKeyboardPlacementInput(nextPosOffset, nextRotOffset);
+
 				if (x_plus) nextPosOffset.x += _manualPlacementPrecision;
 				if (x_minus) nextPosOffset.x -= _manualPlacementPrecision;
 				if (y_plus) nextPosOffset.y += _manualPlacementPrecision;
@@ -2041,12 +2148,16 @@ namespace sub
 				if (z_plus) nextPosOffset.z += _manualPlacementPrecision;
 				if (z_minus) nextPosOffset.z -= _manualPlacementPrecision;
 
-				if (pitch_plus) { nextRotOffset.x += _manualPlacementPrecision; if (nextRotOffset.x > 180.0f) nextRotOffset.x -= 360.0f; }
-				if (pitch_minus) { nextRotOffset.x -= _manualPlacementPrecision; if (nextRotOffset.x < -180.0f) nextRotOffset.x += 360.0f; }
-				if (roll_plus) { nextRotOffset.y += _manualPlacementPrecision; if (nextRotOffset.y > 180.0f) nextRotOffset.y -= 360.0f; }
-				if (roll_minus) { nextRotOffset.y -= _manualPlacementPrecision; if (nextRotOffset.y < -180.0f) nextRotOffset.y += 360.0f; }
-				if (yaw_plus) { nextRotOffset.z += _manualPlacementPrecision; if (nextRotOffset.z > 180.0f) nextRotOffset.z -= 360.0f; }
-				if (yaw_minus) { nextRotOffset.z -= _manualPlacementPrecision; if (nextRotOffset.z < -180.0f) nextRotOffset.z += 360.0f; }
+				if (pitch_plus) nextRotOffset.x += _manualPlacementPrecision;
+				if (pitch_minus) nextRotOffset.x -= _manualPlacementPrecision;
+				if (roll_plus) nextRotOffset.y += _manualPlacementPrecision;
+				if (roll_minus) nextRotOffset.y -= _manualPlacementPrecision;
+				if (yaw_plus) nextRotOffset.z += _manualPlacementPrecision;
+				if (yaw_minus) nextRotOffset.z -= _manualPlacementPrecision;
+
+				WrapAngle(nextRotOffset.x);
+				WrapAngle(nextRotOffset.y);
+				WrapAngle(nextRotOffset.z);
 
 				if (!nextPosOffset.IsZero())
 				{

--- a/Solution/source/Submenus/Spooner/Submenus.h
+++ b/Solution/source/Submenus/Spooner/Submenus.h
@@ -12,12 +12,13 @@
 #include <tuple>
 #include <string>
 
+#include "..\..\Util\GTAmath.h"
+
 typedef unsigned char UINT8, BYTE;
 typedef unsigned int UINT;
 typedef unsigned long DWORD, Hash;
 
 class GTAentity;
-class Vector3;
 
 namespace sub
 {
@@ -27,6 +28,8 @@ namespace sub
 		extern std::tuple<GTAentity, Vector3*, Vector3*> SpoonerVector3ManualPlacementPtrs;
 		extern float _manualPlacementPrecision;
 		extern UINT8 _copyEntTexterValue;
+
+		void HandleKeyboardPlacementInput(Vector3& position, Vector3& rotation);
 
 		void SetEnt241();
 		void SetEnt12();

--- a/Solution/source/Util/GTAmath.cpp
+++ b/Solution/source/Util/GTAmath.cpp
@@ -765,6 +765,13 @@ Vector3 DegreeToRadian(const Vector3& angles)
 {
 	return Vector3(angles.x * 0.0174532925199433F, angles.y * 0.0174532925199433F, angles.z * 0.0174532925199433F);
 }
+
+void WrapAngle(float& angle)
+{
+	while (angle > 180.0f) angle -= 360.0f;
+	while (angle < -180.0f) angle += 360.0f;
+}
+
 float GetHeadingFromCoords(const Vector3& source, const Vector3& target)
 {
 	return atan2((target.y - source.y), (target.x - source.x));

--- a/Solution/source/Util/GTAmath.h
+++ b/Solution/source/Util/GTAmath.h
@@ -871,6 +871,7 @@ float get_random_float_in_range(float min, float max);
 
 float DegreeToRadian(float angle);
 float RadianToDegree(float angle);
+void WrapAngle(float& angle);
 
 Vector3 DegreeToRadian(const Vector3& angles);
 float GetHeadingFromCoords(const Vector3& source, const Vector3& target);


### PR DESCRIPTION
This PR allows users to use their keyboard for manipulating entity position or rotation inside Manual Placement and Attachment Option menus, introducing a way to manipulate entities with something else than the menu buttons which were really clunky.  This (at least partly) fulfills the request from issue #396 (*"and I would like the rotate tool to be better and better movement tool, it would be a great feature."*).

Preview: https://streamable.com/1u2g9q

I have also included an unrelated fix for the player animation settings menu option "flag" that was broken due to the refactor from pr #493 just removing the if statement.
