### PR TITLE
Gizmo manipulation mode for entities

### DIFF
--- a/Solution/source/Submenus/PedAnimation.cpp
+++ b/Solution/source/Submenus/PedAnimation.cpp
@@ -602,6 +602,8 @@ namespace sub
 				g_customAnimDuration -= 100;
 				return;
 			}
+		}
+		if (flagPlus) {
 			for (auto it = AnimFlag::vFlagNames.begin(); it != AnimFlag::vFlagNames.end(); ++it)
 			{
 				if (it->first == g_customAnimFlag)

--- a/Solution/source/Submenus/Spooner/SpoonerMode.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.cpp
@@ -54,6 +54,8 @@ namespace sub::Spooner
 		bool bEnabled = false;
 		bool bIsSomethingHeld = false;
 		bool bHeldEntityHasCollision = true;
+		bool bKeyboardEntityEditingEnabled = false;
+		bool bKeyboardEntityEditingRotationMode = false;
 		Camera spoonerModeCamera;
 		float spoonerModeCameraCamDistance = 5.0f;
 		eSpoonerModeMode& spoonerModeMode = Settings::spoonerModeMode;
@@ -585,10 +587,14 @@ namespace sub::Spooner
 					float movementSensitivity = Settings::cameraMovementSensitivityKeyboard;
 					if (IS_DISABLED_CONTROL_PRESSED(0, INPUT_SPRINT))
 						movementSensitivity = 4.0f * movementSensitivity;
-
-					nextOffset.x = GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_LR) * movementSensitivity;
-					nextOffset.y = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_UD) * movementSensitivity;
-					nextOffset.z = IsKeyDown(VirtualKey::X) ? movementSensitivity / 2 : IsKeyDown(VirtualKey::Z) ? -movementSensitivity / 2 : 0.0f;
+					
+					// blocks camera movements while we are using the keyboard to edit entity pos / rot using the keyboard
+					if (!bKeyboardEntityEditingEnabled)  
+					{
+						nextOffset.x = GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_LR) * movementSensitivity;
+						nextOffset.y = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_UD) * movementSensitivity;
+						nextOffset.z = IsKeyDown(VirtualKey::X) ? movementSensitivity / 2 : IsKeyDown(VirtualKey::Z) ? -movementSensitivity / 2 : 0.0f;
+					}
 
 					float rotationSensitivity = Settings::cameraRotationSensitivityMouse;
 					nextRot.z = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_LOOK_LR) * rotationSensitivity;
@@ -937,6 +943,3 @@ namespace sub::Spooner
 	}
 
 }
-
-
-

--- a/Solution/source/Submenus/Spooner/SpoonerMode.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.cpp
@@ -54,8 +54,9 @@ namespace sub::Spooner
 		bool bEnabled = false;
 		bool bIsSomethingHeld = false;
 		bool bHeldEntityHasCollision = true;
-		bool bKeyboardEntityEditingEnabled = false;
-		bool bKeyboardEntityEditingRotationMode = false;
+		eEntityEditMode entityEditMode = eEntityEditMode::Disabled;
+		bool bEntityEditRotationMode = false;
+		bool bGizmoCameraLocked = false;
 		Camera spoonerModeCamera;
 		float spoonerModeCameraCamDistance = 5.0f;
 		eSpoonerModeMode& spoonerModeMode = Settings::spoonerModeMode;
@@ -588,18 +589,22 @@ namespace sub::Spooner
 					if (IS_DISABLED_CONTROL_PRESSED(0, INPUT_SPRINT))
 						movementSensitivity = 4.0f * movementSensitivity;
 					
-					// blocks camera movements while we are using the keyboard to edit entity pos / rot using the keyboard
-					if (!bKeyboardEntityEditingEnabled)  
+					// blocks camera movement while we are using the keyboard to edit entity pos / rot
+					if (entityEditMode != eEntityEditMode::Keyboard)
 					{
 						nextOffset.x = GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_LR) * movementSensitivity;
 						nextOffset.y = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_MOVE_UD) * movementSensitivity;
 						nextOffset.z = IsKeyDown(VirtualKey::X) ? movementSensitivity / 2 : IsKeyDown(VirtualKey::Z) ? -movementSensitivity / 2 : 0.0f;
 					}
 
-					float rotationSensitivity = Settings::cameraRotationSensitivityMouse;
-					nextRot.z = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_LOOK_LR) * rotationSensitivity;
-					nextRot.x = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_LOOK_UD) * rotationSensitivity;
-					nextRot.y = !IS_DISABLED_CONTROL_PRESSED(2, INPUT_PARACHUTE_BRAKE_RIGHT) ? (IS_DISABLED_CONTROL_PRESSED(2, INPUT_PARACHUTE_BRAKE_LEFT) ? -2.0f : 0.0f) : 2.0f;
+					// blocks camera rotation while we are using the gizmo to edit entity pos / rot
+					if (!bGizmoCameraLocked || entityEditMode != eEntityEditMode::Gizmo)
+					{
+						float rotationSensitivity = Settings::cameraRotationSensitivityMouse;
+						nextRot.z = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_LOOK_LR) * rotationSensitivity;
+						nextRot.x = -GET_DISABLED_CONTROL_NORMAL(0, INPUT_LOOK_UD) * rotationSensitivity;
+						nextRot.y = !IS_DISABLED_CONTROL_PRESSED(2, INPUT_PARACHUTE_BRAKE_RIGHT) ? (IS_DISABLED_CONTROL_PRESSED(2, INPUT_PARACHUTE_BRAKE_LEFT) ? -2.0f : 0.0f) : 2.0f;
+					}
 
 					if (!bIsSomethingHeld || spoonerModeMode == eSpoonerModeMode::GroundEase)
 					{
@@ -665,7 +670,8 @@ namespace sub::Spooner
 						}
 					}
 
-					if (entityInFrontOfCam.Exists() || bIsSomethingHeld)
+					// does not draw the cursor when inside gizmo entity editing mode.
+					if (entityEditMode != eEntityEditMode::Gizmo && (entityInFrontOfCam.Exists() || bIsSomethingHeld))
 					{
 						DRAW_RECT(0.5f, 0.5f, 0.02f, 0.002f, 0, 255, 0, 255, false);
 						DRAW_RECT(0.5f, 0.5f, 0.001f, 0.03f, 0, 255, 0, 255, false);
@@ -861,7 +867,8 @@ namespace sub::Spooner
 							Menu::NewSetMenu(SUB::SPOONER_SELECTEDENTITYOPS);
 						}
 					}
-					else
+					// does not draw the cursor when inside gizmo entity editing mode.
+					else if (entityEditMode != eEntityEditMode::Gizmo)
 					{
 						DRAW_RECT(0.5f, 0.5f, 0.02f, 0.002f, 255, 255, 255, 255, false);
 						DRAW_RECT(0.5f, 0.5f, 0.001f, 0.03f, 255, 255, 255, 255, false);

--- a/Solution/source/Submenus/Spooner/SpoonerMode.h
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.h
@@ -32,6 +32,8 @@ namespace sub::Spooner
 		extern bool bEnabled;
 		extern bool bIsSomethingHeld;
 		extern bool bHeldEntityHasCollision;
+		extern bool bKeyboardEntityEditingEnabled;
+		extern bool bKeyboardEntityEditingRotationMode;
 		extern Camera spoonerModeCamera;
 		extern float spoonerModeCameraCamDistance;
 
@@ -62,6 +64,3 @@ namespace sub::Spooner
 	}
 
 }
-
-
-

--- a/Solution/source/Submenus/Spooner/SpoonerMode.h
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.h
@@ -32,8 +32,11 @@ namespace sub::Spooner
 		extern bool bEnabled;
 		extern bool bIsSomethingHeld;
 		extern bool bHeldEntityHasCollision;
-		extern bool bKeyboardEntityEditingEnabled;
-		extern bool bKeyboardEntityEditingRotationMode;
+
+		enum class eEntityEditMode : UINT8 { Disabled, Keyboard, Gizmo };
+		extern eEntityEditMode entityEditMode;
+		extern bool bEntityEditRotationMode;
+		extern bool bGizmoCameraLocked;
 		extern Camera spoonerModeCamera;
 		extern float spoonerModeCameraCamDistance;
 

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -77,8 +77,89 @@ namespace sub
 		void SetEnt241() { g_Ped1 = selectedEntity.handle.Handle(); }
 		void SetEnt12() { g_Ped4 = selectedEntity.handle.Handle(); }
 
-		void Sub_SpoonerMain()
+		void HandleKeyboardPlacementInput(Vector3& position, Vector3& rotation)
 		{
+			// toggling the keyboard controls on and off
+			static bool lastBToggle = false;
+			bool currentBToggle = IsKeyJustUp(VirtualKey::B);
+			if (currentBToggle && !lastBToggle)
+			{
+				SpoonerMode::bKeyboardEntityEditingEnabled = !SpoonerMode::bKeyboardEntityEditingEnabled;
+			}
+			lastBToggle = currentBToggle;
+			
+			// toggling between the rotation / position modes
+			static bool lastRToggle = false;
+			bool currentRToggle = IsKeyJustUp(VirtualKey::R);
+			if (currentRToggle && !lastRToggle)
+			{
+				SpoonerMode::bKeyboardEntityEditingRotationMode = !SpoonerMode::bKeyboardEntityEditingRotationMode;
+			}
+			lastRToggle = currentRToggle;
+
+			// text drawing variables
+			constexpr float HUD_LINE_HEIGHT = 0.025f;
+			const Vector2 HUD_FONT_SIZE(0.35f, 0.35f);
+			const float hudX = 0.02f;
+			float hudY = 0.8f;
+
+			auto drawText = [&](const std::string& text, RGBA colour = {255, 255, 255, 255})
+			{
+				Game::Print::SetupDraw(GTAfont::Arial, HUD_FONT_SIZE, false, false, true, colour);
+				Game::Print::drawstring(text, hudX, hudY);
+				hudY += HUD_LINE_HEIGHT;
+			};
+
+			if (!SpoonerMode::bKeyboardEntityEditingEnabled)
+			{
+				drawText("~r~Keyboard controls DISABLED.");
+				drawText("~r~You can click B to use your keyboard to position and rotate the entity.");
+				return;
+			}
+
+			if(SpoonerMode::bKeyboardEntityEditingRotationMode) 
+			{
+				drawText("~y~Rotation Mode:");
+				drawText("~b~W/S: ~w~Pitch+ / Pitch-");
+				drawText("~b~A/D: ~w~Yaw+ / Yaw-");
+				drawText("~b~E/Q: ~w~Roll+ / Roll-");
+				drawText("~b~=/-: ~w~+/- Sensitivity");
+				drawText("~b~R: ~w~Toggle position");
+			} else 
+			{
+				drawText("~y~Position Mode:");
+				drawText("~b~W/S: ~w~X+ / X-");
+				drawText("~b~A/D: ~w~Y+ / Y-");
+				drawText("~b~E/Q: ~w~Z+ / Z-");
+				drawText("~b~=/-: ~w~+/- Sensitivity");
+				drawText("~b~R: ~w~Toggle rotation");
+			}
+			drawText("~b~B: ~w~Unlock camera and disable keyboard controls.");
+
+			static DWORD lastSensitivityChange = 0;
+			if (IsKeyJustUp(VirtualKey::OEMPlus) && GetTickCount() - lastSensitivityChange > 200)
+			{
+				if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10;
+				lastSensitivityChange = GetTickCount();
+			}
+			if (IsKeyJustUp(VirtualKey::OEMMinus) && GetTickCount() - lastSensitivityChange > 200)
+			{
+				if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10;
+				lastSensitivityChange = GetTickCount();
+			}
+
+			auto& target = SpoonerMode::bKeyboardEntityEditingRotationMode ? rotation : position;
+			if (IsKeyDown(VirtualKey::W)) target.x += _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::S)) target.x -= _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::A)) target.y += _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::D)) target.y -= _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::E)) target.z += _manualPlacementPrecision;
+			if (IsKeyDown(VirtualKey::Q)) target.z -= _manualPlacementPrecision;
+		}
+
+	void Sub_SpoonerMain()
+		{
+			SpoonerMode::bKeyboardEntityEditingEnabled = false;
 			selectedEntity.handle = 0;
 			_searchStr.clear(); // Sub_SaveFiles _searchStr
 			dict3.clear(); // Sub_SaveFiles _dir
@@ -1038,6 +1119,7 @@ namespace sub
 		}*/
 		void Sub_SelectedEntityOps()
 		{
+			SpoonerMode::bKeyboardEntityEditingEnabled = false;
 			if (!selectedEntity.handle.Exists())
 			{
 				Menu::SetPreviousMenu();
@@ -1377,6 +1459,8 @@ namespace sub
 				Vector3 nextOffset = selectedEntity.attachmentArgs.offset;
 				Vector3 nextRot = selectedEntity.attachmentArgs.rotation;
 
+				HandleKeyboardPlacementInput(nextOffset, nextRot);
+
 				// Bone text scroller if type is PED or VEHICLE. Reattach and reset args on bone change.
 				if (baseEntityType == EntityType::PED)
 				{
@@ -1503,12 +1587,16 @@ namespace sub
 				if (z_plus) nextOffset.z += _manualPlacementPrecision;
 				if (z_minus) nextOffset.z -= _manualPlacementPrecision;
 
-				if (pitch_plus) { nextRot.x += _manualPlacementPrecision; if (nextRot.x > 180.0f) nextRot.x -= 360.0f; }
-				if (pitch_minus) { nextRot.x -= _manualPlacementPrecision; if (nextRot.x < -180.0f) nextRot.x += 360.0f; }
-				if (roll_plus) { nextRot.y += _manualPlacementPrecision; if (nextRot.y > 180.0f) nextRot.y -= 360.0f; }
-				if (roll_minus) { nextRot.y -= _manualPlacementPrecision; if (nextRot.y < -180.0f) nextRot.y += 360.0f; }
-				if (yaw_plus) { nextRot.z += _manualPlacementPrecision; if (nextRot.z > 180.0f) nextRot.z -= 360.0f; }
-				if (yaw_minus) { nextRot.z -= _manualPlacementPrecision; if (nextRot.z < -180.0f) nextRot.z += 360.0f; }
+				if (pitch_plus) nextRot.x += _manualPlacementPrecision;
+				if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
+				if (roll_plus) nextRot.y += _manualPlacementPrecision;
+				if (roll_minus) nextRot.y -= _manualPlacementPrecision;
+				if (yaw_plus) nextRot.z += _manualPlacementPrecision;
+				if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+				WrapAngle(nextRot.x);
+				WrapAngle(nextRot.y);
+				WrapAngle(nextRot.z);
 
 				if (nextOffset != selectedEntity.attachmentArgs.offset || nextRot != selectedEntity.attachmentArgs.rotation || nextBoneIndex != selectedEntity.attachmentArgs.boneIndex)
 				{
@@ -1719,6 +1807,8 @@ namespace sub
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
+			HandleKeyboardPlacementInput(nextPos, nextRot);
+
 			if (x_plus) nextPos.x += _manualPlacementPrecision;
 			if (x_minus) nextPos.x -= _manualPlacementPrecision;
 			if (y_plus) nextPos.y += _manualPlacementPrecision;
@@ -1726,12 +1816,16 @@ namespace sub
 			if (z_plus) nextPos.z += _manualPlacementPrecision;
 			if (z_minus) nextPos.z -= _manualPlacementPrecision;
 
-			if (pitch_plus) { nextRot.x += _manualPlacementPrecision; if (nextRot.x > 180.0f) nextRot.x -= 360.0f; }
-			if (pitch_minus) { nextRot.x -= _manualPlacementPrecision; if (nextRot.x < -180.0f) nextRot.x += 360.0f; }
-			if (roll_plus) { nextRot.y += _manualPlacementPrecision; if (nextRot.y > 180.0f) nextRot.y -= 360.0f; }
-			if (roll_minus) { nextRot.y -= _manualPlacementPrecision; if (nextRot.y < -180.0f) nextRot.y += 360.0f; }
-			if (yaw_plus) { nextRot.z += _manualPlacementPrecision; if (nextRot.z > 180.0f) nextRot.z -= 360.0f; }
-			if (yaw_minus) { nextRot.z -= _manualPlacementPrecision; if (nextRot.z < -180.0f) nextRot.z += 360.0f; }
+			if (pitch_plus) nextRot.x += _manualPlacementPrecision;
+			if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
+			if (roll_plus) nextRot.y += _manualPlacementPrecision;
+			if (roll_minus) nextRot.y -= _manualPlacementPrecision;
+			if (yaw_plus) nextRot.z += _manualPlacementPrecision;
+			if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+			WrapAngle(nextRot.x);
+			WrapAngle(nextRot.y);
+			WrapAngle(nextRot.z);
 
 			if (nextPos != currPos)
 			{
@@ -1898,6 +1992,8 @@ namespace sub
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
+			HandleKeyboardPlacementInput(nextPos, nextRot);
+
 			if (x_plus) nextPos.x += _manualPlacementPrecision;
 			if (x_minus) nextPos.x -= _manualPlacementPrecision;
 			if (y_plus) nextPos.y += _manualPlacementPrecision;
@@ -1905,12 +2001,16 @@ namespace sub
 			if (z_plus) nextPos.z += _manualPlacementPrecision;
 			if (z_minus) nextPos.z -= _manualPlacementPrecision;
 
-			if (pitch_plus) { nextRot.x += _manualPlacementPrecision; if (nextRot.x > 180.0f) nextRot.x -= 360.0f; }
-			if (pitch_minus) { nextRot.x -= _manualPlacementPrecision; if (nextRot.x < -180.0f) nextRot.x += 360.0f; }
-			if (roll_plus) { nextRot.y += _manualPlacementPrecision; if (nextRot.y > 180.0f) nextRot.y -= 360.0f; }
-			if (roll_minus) { nextRot.y -= _manualPlacementPrecision; if (nextRot.y < -180.0f) nextRot.y += 360.0f; }
-			if (yaw_plus) { nextRot.z += _manualPlacementPrecision; if (nextRot.z > 180.0f) nextRot.z -= 360.0f; }
-			if (yaw_minus) { nextRot.z -= _manualPlacementPrecision; if (nextRot.z < -180.0f) nextRot.z += 360.0f; }
+			if (pitch_plus) nextRot.x += _manualPlacementPrecision;
+			if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
+			if (roll_plus) nextRot.y += _manualPlacementPrecision;
+			if (roll_minus) nextRot.y -= _manualPlacementPrecision;
+			if (yaw_plus) nextRot.z += _manualPlacementPrecision;
+			if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+			WrapAngle(nextRot.x);
+			WrapAngle(nextRot.y);
+			WrapAngle(nextRot.z);
 
 			if (nextPos != currPos) selectedEntity.handle.SetPosition(nextPos);
 			if (nextRot != currRot) selectedEntity.handle.SetRotation(nextRot);
@@ -1968,12 +2068,17 @@ namespace sub
 				AddNumber("Pitch", currRot.x, 4, null, pitch_plus, pitch_minus);
 				AddNumber("Roll", currRot.y, 4, null, roll_plus, roll_minus);
 				AddNumber("Yaw", currRot.z, 4, null, yaw_plus, yaw_minus);
-				if (pitch_plus) { nextRot.x += _manualPlacementPrecision; if (nextRot.x > 180.0f) nextRot.x -= 360.0f; }
-				if (pitch_minus) { nextRot.x -= _manualPlacementPrecision; if (nextRot.x < -180.0f) nextRot.x += 360.0f; }
-				if (roll_plus) { nextRot.y += _manualPlacementPrecision; if (nextRot.y > 180.0f) nextRot.y -= 360.0f; }
-				if (roll_minus) { nextRot.y -= _manualPlacementPrecision; if (nextRot.y < -180.0f) nextRot.y += 360.0f; }
-				if (yaw_plus) { nextRot.z += _manualPlacementPrecision; if (nextRot.z > 180.0f) nextRot.z -= 360.0f; }
-				if (yaw_minus) { nextRot.z -= _manualPlacementPrecision; if (nextRot.z < -180.0f) nextRot.z += 360.0f; }
+				
+				if (pitch_plus) nextRot.x += _manualPlacementPrecision;
+				if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
+				if (roll_plus) nextRot.y += _manualPlacementPrecision;
+				if (roll_minus) nextRot.y -= _manualPlacementPrecision;
+				if (yaw_plus) nextRot.z += _manualPlacementPrecision;
+				if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+				WrapAngle(nextRot.x);
+				WrapAngle(nextRot.y);
+				WrapAngle(nextRot.z);
 			}
 
 		}
@@ -2034,6 +2139,8 @@ namespace sub
 				if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 				if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
+				HandleKeyboardPlacementInput(nextPosOffset, nextRotOffset);
+
 				if (x_plus) nextPosOffset.x += _manualPlacementPrecision;
 				if (x_minus) nextPosOffset.x -= _manualPlacementPrecision;
 				if (y_plus) nextPosOffset.y += _manualPlacementPrecision;
@@ -2041,12 +2148,16 @@ namespace sub
 				if (z_plus) nextPosOffset.z += _manualPlacementPrecision;
 				if (z_minus) nextPosOffset.z -= _manualPlacementPrecision;
 
-				if (pitch_plus) { nextRotOffset.x += _manualPlacementPrecision; if (nextRotOffset.x > 180.0f) nextRotOffset.x -= 360.0f; }
-				if (pitch_minus) { nextRotOffset.x -= _manualPlacementPrecision; if (nextRotOffset.x < -180.0f) nextRotOffset.x += 360.0f; }
-				if (roll_plus) { nextRotOffset.y += _manualPlacementPrecision; if (nextRotOffset.y > 180.0f) nextRotOffset.y -= 360.0f; }
-				if (roll_minus) { nextRotOffset.y -= _manualPlacementPrecision; if (nextRotOffset.y < -180.0f) nextRotOffset.y += 360.0f; }
-				if (yaw_plus) { nextRotOffset.z += _manualPlacementPrecision; if (nextRotOffset.z > 180.0f) nextRotOffset.z -= 360.0f; }
-				if (yaw_minus) { nextRotOffset.z -= _manualPlacementPrecision; if (nextRotOffset.z < -180.0f) nextRotOffset.z += 360.0f; }
+				if (pitch_plus) nextRotOffset.x += _manualPlacementPrecision;
+				if (pitch_minus) nextRotOffset.x -= _manualPlacementPrecision;
+				if (roll_plus) nextRotOffset.y += _manualPlacementPrecision;
+				if (roll_minus) nextRotOffset.y -= _manualPlacementPrecision;
+				if (yaw_plus) nextRotOffset.z += _manualPlacementPrecision;
+				if (yaw_minus) nextRotOffset.z -= _manualPlacementPrecision;
+
+				WrapAngle(nextRotOffset.x);
+				WrapAngle(nextRotOffset.y);
+				WrapAngle(nextRotOffset.z);
 
 				if (!nextPosOffset.IsZero())
 				{

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -38,6 +38,7 @@
 #include "SpoonerEntity.h"
 #include "SpoonerMode.h"
 #include "SpoonerSettings.h"
+#include "TransformGizmo.h"
 #include "Databases.h"
 #include "FileManagement.h"
 #include "EntityManagement.h"
@@ -77,27 +78,8 @@ namespace sub
 		void SetEnt241() { g_Ped1 = selectedEntity.handle.Handle(); }
 		void SetEnt12() { g_Ped4 = selectedEntity.handle.Handle(); }
 
-		void HandleKeyboardPlacementInput(Vector3& position, Vector3& rotation)
+		void HandleKeyboardManipulation(Vector3& position, Vector3& rotation)
 		{
-			// toggling the keyboard controls on and off
-			static bool lastBToggle = false;
-			bool currentBToggle = IsKeyJustUp(VirtualKey::B);
-			if (currentBToggle && !lastBToggle)
-			{
-				SpoonerMode::bKeyboardEntityEditingEnabled = !SpoonerMode::bKeyboardEntityEditingEnabled;
-			}
-			lastBToggle = currentBToggle;
-			
-			// toggling between the rotation / position modes
-			static bool lastRToggle = false;
-			bool currentRToggle = IsKeyJustUp(VirtualKey::R);
-			if (currentRToggle && !lastRToggle)
-			{
-				SpoonerMode::bKeyboardEntityEditingRotationMode = !SpoonerMode::bKeyboardEntityEditingRotationMode;
-			}
-			lastRToggle = currentRToggle;
-
-			// text drawing variables
 			constexpr float HUD_LINE_HEIGHT = 0.025f;
 			const Vector2 HUD_FONT_SIZE(0.35f, 0.35f);
 			const float hudX = 0.02f;
@@ -110,14 +92,7 @@ namespace sub
 				hudY += HUD_LINE_HEIGHT;
 			};
 
-			if (!SpoonerMode::bKeyboardEntityEditingEnabled)
-			{
-				drawText("~r~Keyboard controls DISABLED.");
-				drawText("~r~You can click B to use your keyboard to position and rotate the entity.");
-				return;
-			}
-
-			if(SpoonerMode::bKeyboardEntityEditingRotationMode) 
+			if (SpoonerMode::bEntityEditRotationMode)
 			{
 				drawText("~y~Rotation Mode:");
 				drawText("~b~W/S: ~w~Pitch+ / Pitch-");
@@ -125,7 +100,8 @@ namespace sub
 				drawText("~b~E/Q: ~w~Roll+ / Roll-");
 				drawText("~b~=/-: ~w~+/- Sensitivity");
 				drawText("~b~R: ~w~Toggle position");
-			} else 
+			}
+			else
 			{
 				drawText("~y~Position Mode:");
 				drawText("~b~W/S: ~w~X+ / X-");
@@ -134,7 +110,7 @@ namespace sub
 				drawText("~b~=/-: ~w~+/- Sensitivity");
 				drawText("~b~R: ~w~Toggle rotation");
 			}
-			drawText("~b~B: ~w~Unlock camera and disable keyboard controls.");
+			drawText("~b~B: ~w~Switch to gizmo / disable controls.");
 
 			static DWORD lastSensitivityChange = 0;
 			if (IsKeyJustUp(VirtualKey::OEMPlus) && GetTickCount() - lastSensitivityChange > 200)
@@ -148,7 +124,7 @@ namespace sub
 				lastSensitivityChange = GetTickCount();
 			}
 
-			auto& target = SpoonerMode::bKeyboardEntityEditingRotationMode ? rotation : position;
+			auto& target = SpoonerMode::bEntityEditRotationMode ? rotation : position;
 			if (IsKeyDown(VirtualKey::W)) target.x += _manualPlacementPrecision;
 			if (IsKeyDown(VirtualKey::S)) target.x -= _manualPlacementPrecision;
 			if (IsKeyDown(VirtualKey::A)) target.y += _manualPlacementPrecision;
@@ -157,9 +133,149 @@ namespace sub
 			if (IsKeyDown(VirtualKey::Q)) target.z -= _manualPlacementPrecision;
 		}
 
+		void HandleGizmoManipulation()
+		{
+			constexpr float HUD_LINE_HEIGHT = 0.025f;
+			const Vector2 HUD_FONT_SIZE(0.35f, 0.35f);
+			const float hudX = 0.02f;
+			float hudY = 0.8f;
+
+			auto drawText = [&](const std::string& text, RGBA colour = {255, 255, 255, 255})
+			{
+				Game::Print::SetupDraw(GTAfont::Arial, HUD_FONT_SIZE, false, false, true, colour);
+				Game::Print::drawstring(text, hudX, hudY);
+				hudY += HUD_LINE_HEIGHT;
+			};
+
+			if (selectedEntity.handle.Exists())
+			{
+				static TransformGizmo gizmo;
+				gizmo.SetMode(SpoonerMode::bEntityEditRotationMode ? GizmoMode::Rotate : GizmoMode::Translate);
+				gizmo.Update();
+				gizmo.Draw(selectedEntity.handle.GetPosition());
+				if (gizmo.IsActive())
+					gizmo.ApplyMovement(selectedEntity.handle);
+			}
+
+			if (SpoonerMode::bEntityEditRotationMode)
+				drawText("~y~Gizmo Mode ~s~(Rotation Mode):");
+			else
+				drawText("~y~Gizmo Mode ~s~(Position Mode):");
+			drawText("~b~Left Click:~w~ Grab axis handle");
+			drawText("~b~R:~w~ Toggle position/rotation");
+			drawText("~b~B:~w~ Disable controls");
+			drawText(SpoonerMode::bGizmoCameraLocked ? "~r~Camera LOCKED ~s~- Mouse drag freely" : "~g~Camera UNLOCKED ~s~- Mouse rotates camera");
+			drawText("~b~C:~w~ Toggle camera lock");
+		}
+
+		void HandleGizmoAttachmentManipulation(GTAentity& parentEntity, Vector3& position, Vector3& rotation)
+		{
+			constexpr float HUD_LINE_HEIGHT = 0.025f;
+			const Vector2 HUD_FONT_SIZE(0.35f, 0.35f);
+			const float hudX = 0.02f;
+			float hudY = 0.8f;
+
+			auto drawText = [&](const std::string& text, RGBA colour = {255, 255, 255, 255})
+			{
+				Game::Print::SetupDraw(GTAfont::Arial, HUD_FONT_SIZE, false, false, true, colour);
+				Game::Print::drawstring(text, hudX, hudY);
+				hudY += HUD_LINE_HEIGHT;
+			};
+
+			static TransformGizmo gizmo;
+			gizmo.SetMode(SpoonerMode::bEntityEditRotationMode ? GizmoMode::Rotate : GizmoMode::Translate);
+			gizmo.ApplyAttachmentMovement(parentEntity, selectedEntity.handle, position, rotation, selectedEntity.attachmentArgs.boneIndex);
+
+			if (SpoonerMode::bEntityEditRotationMode)
+				drawText("~y~Gizmo Mode ~s~(Rotation Mode):");
+			else
+				drawText("~y~Gizmo Mode ~s~(Position Mode):");
+			drawText("~b~Left Click:~w~ Grab axis handle");
+			drawText("~b~R:~w~ Toggle position/rotation");
+			drawText("~b~B:~w~ Disable controls");
+			drawText(SpoonerMode::bGizmoCameraLocked ? "~r~Camera LOCKED ~s~- Mouse drag freely" : "~g~Camera UNLOCKED ~s~- Mouse rotates camera");
+			drawText("~b~C:~w~ Toggle camera lock");
+		}
+
+		void HandleEntityEditingLogic(Vector3& position, Vector3& rotation, GTAentity* parentEntity)
+		{
+			// toggling between Disabled / Keyboard / Gizmo modes
+			static bool lastBToggle = false;
+			bool currentBToggle = IsKeyJustUp(VirtualKey::B);
+			if (currentBToggle && !lastBToggle)
+			{
+				switch (SpoonerMode::entityEditMode)
+				{
+				case SpoonerMode::eEntityEditMode::Disabled:
+					SpoonerMode::entityEditMode = SpoonerMode::eEntityEditMode::Keyboard;
+					SpoonerMode::bGizmoCameraLocked = false;
+					break;
+				case SpoonerMode::eEntityEditMode::Keyboard:
+					SpoonerMode::entityEditMode = SpoonerMode::eEntityEditMode::Gizmo;
+					SpoonerMode::bGizmoCameraLocked = false;
+					break;
+				case SpoonerMode::eEntityEditMode::Gizmo:
+					SpoonerMode::entityEditMode = SpoonerMode::eEntityEditMode::Disabled;
+					SpoonerMode::bGizmoCameraLocked = false;
+					break;
+				}
+			}
+			lastBToggle = currentBToggle;
+
+			// toggling between the rotation / position modes
+			static bool lastRToggle = false;
+			bool currentRToggle = IsKeyJustUp(VirtualKey::R);
+			if (currentRToggle && !lastRToggle)
+			{
+				SpoonerMode::bEntityEditRotationMode = !SpoonerMode::bEntityEditRotationMode;
+			}
+			lastRToggle = currentRToggle;
+
+			// toggling camera lock in gizmo mode
+			if (SpoonerMode::entityEditMode == SpoonerMode::eEntityEditMode::Gizmo && IsKeyJustUp(VirtualKey::C))
+			{
+				SpoonerMode::bGizmoCameraLocked = !SpoonerMode::bGizmoCameraLocked;
+			}
+
+			constexpr float HUD_LINE_HEIGHT = 0.025f;
+			const Vector2 HUD_FONT_SIZE(0.35f, 0.35f);
+			const float hudX = 0.02f;
+			float hudY = 0.8f;
+
+			auto drawText = [&](const std::string& text, RGBA colour = {255, 255, 255, 255})
+			{
+				Game::Print::SetupDraw(GTAfont::Arial, HUD_FONT_SIZE, false, false, true, colour);
+				Game::Print::drawstring(text, hudX, hudY);
+				hudY += HUD_LINE_HEIGHT;
+			};
+
+			if (SpoonerMode::entityEditMode == SpoonerMode::eEntityEditMode::Disabled)
+			{
+				drawText("~r~Entity manipulation DISABLED.");
+				drawText("~b~Press B:~w~ Enable keyboard controls or gizmo editing mode.");
+				return;
+			}
+
+			if (SpoonerMode::entityEditMode == SpoonerMode::eEntityEditMode::Keyboard)
+			{
+				HandleKeyboardManipulation(position, rotation);
+			}
+			else if (SpoonerMode::entityEditMode == SpoonerMode::eEntityEditMode::Gizmo)
+			{
+				if (parentEntity != nullptr && parentEntity->Exists())
+				{
+					HandleGizmoAttachmentManipulation(*parentEntity, position, rotation);
+				}
+				else
+				{
+					HandleGizmoManipulation();
+				}
+			}
+		}
+
 	void Sub_SpoonerMain()
 		{
-			SpoonerMode::bKeyboardEntityEditingEnabled = false;
+			SpoonerMode::entityEditMode = SpoonerMode::eEntityEditMode::Disabled;
 			selectedEntity.handle = 0;
 			_searchStr.clear(); // Sub_SaveFiles _searchStr
 			dict3.clear(); // Sub_SaveFiles _dir
@@ -1119,7 +1235,7 @@ namespace sub
 		}*/
 		void Sub_SelectedEntityOps()
 		{
-			SpoonerMode::bKeyboardEntityEditingEnabled = false;
+			SpoonerMode::entityEditMode = SpoonerMode::eEntityEditMode::Disabled;
 			if (!selectedEntity.handle.Exists())
 			{
 				Menu::SetPreviousMenu();
@@ -1421,9 +1537,9 @@ namespace sub
 				Databases::EntityDb[thisEntityIndexInDb] = selectedEntity;
 			}
 
-			GTAentity baseEntityIfExists;
-			bool seIsAttached = EntityManagement::GetEntityThisEntityIsAttachedTo(selectedEntity.handle, baseEntityIfExists);
-			EntityType baseEntityType = (EntityType)baseEntityIfExists.Type();
+			GTAentity parentEntity;
+			bool seIsAttached = EntityManagement::GetEntityThisEntityIsAttachedTo(selectedEntity.handle, parentEntity);
+			EntityType parentEntityType = (EntityType)parentEntity.Type();
 
 			bool prec_plus = 0, prec_minus = 0;
 
@@ -1459,15 +1575,15 @@ namespace sub
 				Vector3 nextOffset = selectedEntity.attachmentArgs.offset;
 				Vector3 nextRot = selectedEntity.attachmentArgs.rotation;
 
-				HandleKeyboardPlacementInput(nextOffset, nextRot);
+				HandleEntityEditingLogic(nextOffset, nextRot, &parentEntity);
 
 				// Bone text scroller if type is PED or VEHICLE. Reattach and reset args on bone change.
-				if (baseEntityType == EntityType::PED)
+				if (parentEntityType == EntityType::PED)
 				{
 					int obj_currentPedBoneArrayIndex = 17; // SKEL_ROOT is at index 17 idk
 					for (int i = 0; i < Bone::vBoneNames.size(); i++)
 					{
-						if (nextBoneIndex == GTAped(baseEntityIfExists).GetBoneIndex(Bone::vBoneNames[i].boneid))
+						if (nextBoneIndex == GTAped(parentEntity).GetBoneIndex(Bone::vBoneNames[i].boneid))
 						{
 							obj_currentPedBoneArrayIndex = i;
 							break;
@@ -1482,7 +1598,7 @@ namespace sub
 						if (obj_currentPedBoneArrayIndex < Bone::vBoneNames.size() - 1)
 						{
 							obj_currentPedBoneArrayIndex++;
-							nextBoneIndex = GTAped(baseEntityIfExists).GetBoneIndex(Bone::vBoneNames[obj_currentPedBoneArrayIndex].boneid);
+							nextBoneIndex = GTAped(parentEntity).GetBoneIndex(Bone::vBoneNames[obj_currentPedBoneArrayIndex].boneid);
 							//nextOffset = Vector3::Zero();
 							//nextRot = Vector3::Zero();
 						}
@@ -1492,7 +1608,7 @@ namespace sub
 						if (obj_currentPedBoneArrayIndex > 0)
 						{
 							obj_currentPedBoneArrayIndex--;
-							nextBoneIndex = GTAped(baseEntityIfExists).GetBoneIndex(Bone::vBoneNames[obj_currentPedBoneArrayIndex].boneid);
+							nextBoneIndex = GTAped(parentEntity).GetBoneIndex(Bone::vBoneNames[obj_currentPedBoneArrayIndex].boneid);
 							//nextOffset = Vector3::Zero();
 							//nextRot = Vector3::Zero();
 						}
@@ -1506,7 +1622,7 @@ namespace sub
 						//	if (pb.name.find(srch) != std::string::npos)
 						//	{
 						//		bool found = true;
-						//		nextBoneIndex = GTAped(baseEntityIfExists).GetBoneIndex(pb.boneid);
+						//		nextBoneIndex = GTAped(parentEntity).GetBoneIndex(pb.boneid);
 						//		//obj_currentPedBoneArrayIndex = index; // Not needed
 						//		nextOffset = Vector3::Zero();
 						//		nextRot = Vector3::Zero();
@@ -1517,12 +1633,12 @@ namespace sub
 						Menu::SetSub_delayed = SUB::SPOONER_ATTACHMENTOPS_SELECTBONE;
 					}
 				}
-				else if (baseEntityType == EntityType::VEHICLE)
+				else if (parentEntityType == EntityType::VEHICLE)
 				{
 					int obj_currentVehBoneArrayIndex = 10; // 10 is bodyshell idk
 					for (int i = 0; i < VBone::vNames.size(); i++)
 					{
-						if (nextBoneIndex == GTAvehicle(baseEntityIfExists).GetBoneIndex(VBone::vNames[i]))
+						if (nextBoneIndex == GTAvehicle(parentEntity).GetBoneIndex(VBone::vNames[i]))
 						{
 							obj_currentVehBoneArrayIndex = i;
 							break;
@@ -1537,7 +1653,7 @@ namespace sub
 						if (obj_currentVehBoneArrayIndex < VBone::vNames.size() - 1)
 						{
 							obj_currentVehBoneArrayIndex++;
-							nextBoneIndex = GTAvehicle(baseEntityIfExists).GetBoneIndex(VBone::vNames[obj_currentVehBoneArrayIndex]);
+							nextBoneIndex = GTAvehicle(parentEntity).GetBoneIndex(VBone::vNames[obj_currentVehBoneArrayIndex]);
 							//nextOffset = Vector3::Zero();
 							//nextRot = Vector3::Zero();
 						}
@@ -1547,7 +1663,7 @@ namespace sub
 						if (obj_currentVehBoneArrayIndex > 0)
 						{
 							obj_currentVehBoneArrayIndex--;
-							nextBoneIndex = GTAvehicle(baseEntityIfExists).GetBoneIndex(VBone::vNames[obj_currentVehBoneArrayIndex]);
+							nextBoneIndex = GTAvehicle(parentEntity).GetBoneIndex(VBone::vNames[obj_currentVehBoneArrayIndex]);
 							//nextOffset = Vector3::Zero();
 							//nextRot = Vector3::Zero();
 						}
@@ -1561,7 +1677,7 @@ namespace sub
 						//	if (vbn.find(srch) != std::string::npos)
 						//	{
 						//		bool found = true;
-						//		nextBoneIndex = GTAvehicle(baseEntityIfExists).GetBoneIndex(vbn);
+						//		nextBoneIndex = GTAvehicle(parentEntity).GetBoneIndex(vbn);
 						//		//obj_currentVehBoneArrayIndex = index; // Not needed
 						//		nextOffset = Vector3::Zero();
 						//		nextRot = Vector3::Zero();
@@ -1600,7 +1716,7 @@ namespace sub
 
 				if (nextOffset != selectedEntity.attachmentArgs.offset || nextRot != selectedEntity.attachmentArgs.rotation || nextBoneIndex != selectedEntity.attachmentArgs.boneIndex)
 				{
-					EntityManagement::AttachEntity(selectedEntity, baseEntityIfExists, nextBoneIndex, nextOffset, nextRot);
+					EntityManagement::AttachEntity(selectedEntity, parentEntity, nextBoneIndex, nextOffset, nextRot);
 				}
 			}
 
@@ -1701,7 +1817,7 @@ namespace sub
 
 			GTAentity baseEntity;
 			bool seIsAttached = EntityManagement::GetEntityThisEntityIsAttachedTo(selectedEntity.handle, baseEntity);
-			EntityType baseEntityType = (EntityType)baseEntity.Type();
+			EntityType parentEntityType = (EntityType)baseEntity.Type();
 			if (!baseEntity.Exists())
 			{
 				Menu::SetPreviousMenu();
@@ -1719,7 +1835,7 @@ namespace sub
 			AddTitle("Bone");
 
 			// Bone text scroller if type is PED or VEHICLE. Reattach and reset args on bone change.
-			if (baseEntityType == EntityType::PED)
+			if (parentEntityType == EntityType::PED)
 			{
 				GTAped baseEntityPed = baseEntity;
 				defaultBone = baseEntityPed.GetBoneIndex(Bone::SKEL_ROOT);
@@ -1742,7 +1858,7 @@ namespace sub
 					}
 				}
 			}
-			else if (baseEntityType == EntityType::VEHICLE)
+			else if (parentEntityType == EntityType::VEHICLE)
 			{
 				GTAvehicle baseEntityVeh = baseEntity;
 				defaultBone = baseEntityVeh.GetBoneIndex(VBone::bodyshell);
@@ -1807,7 +1923,7 @@ namespace sub
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
-			HandleKeyboardPlacementInput(nextPos, nextRot);
+			HandleEntityEditingLogic(nextPos, nextRot, nullptr);
 
 			if (x_plus) nextPos.x += _manualPlacementPrecision;
 			if (x_minus) nextPos.x -= _manualPlacementPrecision;
@@ -1992,7 +2108,7 @@ namespace sub
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
-			HandleKeyboardPlacementInput(nextPos, nextRot);
+			HandleEntityEditingLogic(nextPos, nextRot, nullptr);
 
 			if (x_plus) nextPos.x += _manualPlacementPrecision;
 			if (x_minus) nextPos.x -= _manualPlacementPrecision;
@@ -2139,7 +2255,7 @@ namespace sub
 				if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 				if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
-				HandleKeyboardPlacementInput(nextPosOffset, nextRotOffset);
+				// HandleEntityEditingLogic(nextPosOffset, nextRotOffset, nullptr); // doesn't really work as expected, just applies the delta to all objects instead of calculating a centroid and making changes based on it. 
 
 				if (x_plus) nextPosOffset.x += _manualPlacementPrecision;
 				if (x_minus) nextPosOffset.x -= _manualPlacementPrecision;

--- a/Solution/source/Submenus/Spooner/Submenus.h
+++ b/Solution/source/Submenus/Spooner/Submenus.h
@@ -12,12 +12,13 @@
 #include <tuple>
 #include <string>
 
+#include "..\..\Util\GTAmath.h"
+
 typedef unsigned char UINT8, BYTE;
 typedef unsigned int UINT;
 typedef unsigned long DWORD, Hash;
 
 class GTAentity;
-class Vector3;
 
 namespace sub
 {
@@ -27,6 +28,8 @@ namespace sub
 		extern std::tuple<GTAentity, Vector3*, Vector3*> SpoonerVector3ManualPlacementPtrs;
 		extern float _manualPlacementPrecision;
 		extern UINT8 _copyEntTexterValue;
+
+		void HandleKeyboardPlacementInput(Vector3& position, Vector3& rotation);
 
 		void SetEnt241();
 		void SetEnt12();

--- a/Solution/source/Submenus/Spooner/TransformGizmo.cpp
+++ b/Solution/source/Submenus/Spooner/TransformGizmo.cpp
@@ -1,0 +1,443 @@
+/*
+* Menyoo PC - Grand Theft Auto V single-player trainer mod
+* Copyright (C) 2019  MAFINS
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*/
+#include "TransformGizmo.h"
+
+#include "..\..\Natives\natives2.h"
+#include "..\..\Scripting\World.h"
+#include "..\..\Scripting\GameplayCamera.h"
+#include "..\..\Scripting\Game.h"
+#include "..\..\Scripting\Model.h"
+#include "..\..\Scripting\GTAentity.h"
+#include "..\..\Scripting\enums.h"
+#include "SpoonerEntity.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+	constexpr float TRANSLATE_SENSITIVITY = 3.0f;
+	constexpr float TRANSLATE_SENSITIVITY_MAX = 15.0f;
+	constexpr float ROTATE_SENSITIVITY = 180.0f;
+	constexpr float AXIS_SCALE_MIN = 0.5f;
+	constexpr float AXIS_SCALE_MAX = 10.0f;
+	constexpr float ATTACHMENT_DEADZONE = 0.0005f;
+	constexpr float AXIS_SCALE_FACTOR = 1.5f;
+	constexpr float HANDLE_PICK_RADIUS = 0.035f;
+	constexpr float LABEL_RECT_W = 0.025f;
+	constexpr float LABEL_RECT_H = 0.022f;
+	constexpr float LABEL_Y_OFFSET = 0.008f; // 0.01f = bit too high 
+	constexpr float SCREEN_DIR_MIN_LENGTH = 0.001f;
+
+	constexpr const char* TRANS_LABEL_X = "X";
+	constexpr const char* TRANS_LABEL_Y = "Y";
+	constexpr const char* TRANS_LABEL_Z = "Z";
+	constexpr const char* ROT_LABEL_X = "PITCH";
+	constexpr const char* ROT_LABEL_Y = "ROLL";
+	constexpr const char* ROT_LABEL_Z = "YAW";
+}
+
+TransformGizmo::TransformGizmo()
+	: mode(GizmoMode::Translate)
+{
+}
+
+void TransformGizmo::FrameData::ComputeForEntity(GTAentity& entity, const Vector3& worldPos)
+{
+	distanceToEntity = GameplayCamera::GetPosition().DistanceTo(worldPos);
+
+	Vector3 rotation = entity.Rotation_get();
+	float yaw = DegreeToRadian(rotation.z);
+	float pitch = DegreeToRadian(rotation.y);
+	float roll = DegreeToRadian(rotation.x);
+
+	float cY = std::cos(yaw), sY = std::sin(yaw);
+	float cP = std::cos(pitch), sP = std::sin(pitch);
+	float cR = std::cos(roll), sR = std::sin(roll);
+
+	localAxes[0] = Vector3(cY * cP, sY * cP, -sP);
+	localAxes[1] = Vector3(-sY * cR + cY * sP * sR, cY * cR + sY * sP * sR, cP * sR);
+	localAxes[2] = Vector3(sY * sR + cY * sP * cR, -cY * sR + sY * sP * cR, cP * cR);
+
+	auto dims = entity.ModelDimensions();
+	float halfX = std::abs(dims.Dim2.x - dims.Dim1.x) * 0.5f;
+	float halfY = std::abs(dims.Dim2.y - dims.Dim1.y) * 0.5f;
+	float halfZ = std::abs(dims.Dim2.z - dims.Dim1.z) * 0.5f;
+
+	axisScales[0] = std::clamp(halfX * AXIS_SCALE_FACTOR, AXIS_SCALE_MIN, AXIS_SCALE_MAX);
+	axisScales[1] = std::clamp(halfY * AXIS_SCALE_FACTOR, AXIS_SCALE_MIN, AXIS_SCALE_MAX);
+	axisScales[2] = std::clamp(halfZ * AXIS_SCALE_FACTOR, AXIS_SCALE_MIN, AXIS_SCALE_MAX);
+}
+
+void TransformGizmo::FrameData::ComputeAxisScreenProjections(const Vector3& worldPos, const Vector2& entityScreenPos, bool entityOnScreen)
+{
+	for (int i = 0; i < 3; i++)
+	{
+		Vector3 handleWorld = worldPos + localAxes[i] * axisScales[i];
+		handlePositions[i].isOnScreen = World::WorldToScreen(handleWorld, handlePositions[i].screenPos);
+
+		if (entityOnScreen && handlePositions[i].isOnScreen)
+		{
+			Vector2 dir = handlePositions[i].screenPos - entityScreenPos;
+			float len = dir.Length();
+			axisScreenProjections[i] = (len > SCREEN_DIR_MIN_LENGTH) ? dir / len : Vector2::Zero();
+		}
+		else
+		{
+			axisScreenProjections[i] = Vector2::Zero();
+		}
+	}
+}
+
+Vector3 TransformGizmo::GetLocalAxis(GizmoAxis axis) const
+{
+	int idx = AxisIndex(axis);
+	return (idx >= 0) ? frame.localAxes[idx] : Vector3::Zero();
+}
+
+float TransformGizmo::GetAxisScale(GizmoAxis axis) const
+{
+	int idx = AxisIndex(axis);
+	return (idx >= 0) ? frame.axisScales[idx] : 1.0f;
+}
+
+int TransformGizmo::AxisIndex(GizmoAxis axis) const
+{
+	int idx = static_cast<int>(axis) - 1;
+	return (idx >= 0 && idx < 3) ? idx : -1;
+}
+
+const char* TransformGizmo::GetAxisLabel(GizmoAxis axis) const
+{
+	bool isRot = (mode == GizmoMode::Rotate);
+	switch (axis)
+	{
+	case GizmoAxis::X: return isRot ? ROT_LABEL_X : TRANS_LABEL_X;
+	case GizmoAxis::Y: return isRot ? ROT_LABEL_Y : TRANS_LABEL_Y;
+	case GizmoAxis::Z: return isRot ? ROT_LABEL_Z : TRANS_LABEL_Z;
+	default: return "?";
+	}
+}
+
+Vector2 TransformGizmo::GetCursorPos() const
+{
+	return Vector2(
+		GET_DISABLED_CONTROL_NORMAL(2, INPUT_CURSOR_X),
+		GET_DISABLED_CONTROL_NORMAL(2, INPUT_CURSOR_Y)
+	);
+}
+
+float TransformGizmo::NormalizeAngle(float angle)
+{
+	return fmodf(fmodf(angle, 360.0f) + 360.0f, 360.0f);
+}
+
+void TransformGizmo::ApplyRotationDelta(Vector3& rotation, GizmoAxis axis, const Vector2& delta)
+{
+	float rotationDelta = 0.0f;
+	switch (axis)
+	{
+	case GizmoAxis::X: rotationDelta = -delta.y * ROTATE_SENSITIVITY; break;
+	case GizmoAxis::Y: rotationDelta = -delta.x * ROTATE_SENSITIVITY; break;
+	case GizmoAxis::Z: rotationDelta = delta.x * ROTATE_SENSITIVITY; break;
+	default: break;
+	}
+
+	switch (axis)
+	{
+	case GizmoAxis::X: rotation.x = NormalizeAngle(rotation.x + rotationDelta); break;
+	case GizmoAxis::Y: rotation.y = NormalizeAngle(rotation.y + rotationDelta); break;
+	case GizmoAxis::Z: rotation.z = NormalizeAngle(rotation.z + rotationDelta); break;
+	default: break;
+	}
+}
+
+Vector3 TransformGizmo::WorldToBoneRelative(const Vector3& worldOffset, const Vector3& boneRotEuler) const
+{
+	float yaw = DegreeToRadian(boneRotEuler.z);
+	float pitch = DegreeToRadian(boneRotEuler.y);
+	float roll = DegreeToRadian(boneRotEuler.x);
+
+	float cY = std::cos(yaw), sY = std::sin(yaw);
+	float cP = std::cos(pitch), sP = std::sin(pitch);
+	float cR = std::cos(roll), sR = std::sin(roll);
+
+	Vector3 xAxis(cY * cP, sY * cP, -sP);
+	Vector3 yAxis(-sY * cR + cY * sP * sR, cY * cR + sY * sP * sR, cP * sR);
+	Vector3 zAxis(sY * sR + cY * sP * cR, -cY * sR + sY * sP * cR, cP * cR);
+
+	return Vector3(
+		Vector3::Dot(worldOffset, xAxis),
+		Vector3::Dot(worldOffset, yAxis),
+		Vector3::Dot(worldOffset, zAxis)
+	);
+}
+
+float TransformGizmo::GetDistanceBasedSensitivity() const
+{
+	return std::clamp(TRANSLATE_SENSITIVITY + frame.distanceToEntity * 0.1f,
+		TRANSLATE_SENSITIVITY, TRANSLATE_SENSITIVITY_MAX);
+}
+
+void TransformGizmo::Update()
+{
+	SET_MOUSE_CURSOR_VISIBLE(true);
+	SET_MOUSE_CURSOR_THIS_FRAME();
+
+	Vector2 cursorPos = GetCursorPos();
+
+	GTAentity selectedEntity = sub::Spooner::selectedEntity.handle;
+	if (!selectedEntity.Exists())
+		return;
+
+	Vector3 entityPos = selectedEntity.GetPosition();
+	Vector2 entityScreen;
+	bool entityOnScreen = World::WorldToScreen(entityPos, entityScreen);
+
+	frame.ComputeForEntity(selectedEntity, entityPos);
+	frame.ComputeAxisScreenProjections(entityPos, entityScreen, entityOnScreen);
+
+	drag.hoveredAxis = FindAxisAtCursor(cursorPos);
+
+	if (IS_DISABLED_CONTROL_PRESSED(2, INPUT_CURSOR_ACCEPT))
+	{
+		if (drag.activeAxis == GizmoAxis::None && drag.hoveredAxis != GizmoAxis::None)
+		{
+			drag.activeAxis = drag.hoveredAxis;
+			drag.startCursorPos = cursorPos;
+			drag.startPos = entityPos;
+			drag.startRotation = selectedEntity.Rotation_get();
+		}
+	}
+	else
+	{
+		drag.activeAxis = GizmoAxis::None;
+	}
+}
+
+void TransformGizmo::ApplyMovement(GTAentity& entity)
+{
+	if (drag.activeAxis == GizmoAxis::None || !entity.Exists())
+		return;
+
+	Vector2 cursorPos = GetCursorPos();
+	Vector2 delta = cursorPos - drag.startCursorPos;
+
+	Vector3 axisDir = GetLocalAxis(drag.activeAxis);
+
+	if (mode == GizmoMode::Translate)
+	{
+		int idx = AxisIndex(drag.activeAxis);
+		Vector2 screenDir = frame.axisScreenProjections[idx];
+		float movement = delta.x * screenDir.x + delta.y * screenDir.y;
+
+		movement *= GetDistanceBasedSensitivity() * GetAxisScale(drag.activeAxis);
+		Vector3 newPos = drag.startPos + axisDir * movement;
+		SET_ENTITY_COORDS_NO_OFFSET(entity.GetHandle(), newPos.x, newPos.y, newPos.z, false, false, false);
+	}
+	else if (mode == GizmoMode::Rotate)
+	{
+		Vector3 newRot = drag.startRotation;
+		ApplyRotationDelta(newRot, drag.activeAxis, delta);
+		entity.SetRotation(newRot);
+	}
+}
+
+GizmoAxis TransformGizmo::GetActiveAxis() const
+{
+	return drag.activeAxis;
+}
+
+GizmoMode TransformGizmo::GetMode() const
+{
+	return mode;
+}
+
+void TransformGizmo::SetMode(GizmoMode newMode)
+{
+	if (mode != newMode)
+	{
+		mode = newMode;
+		drag.activeAxis = GizmoAxis::None;
+	}
+}
+
+bool TransformGizmo::IsActive() const
+{
+	return drag.IsActive();
+}
+
+Vector3 TransformGizmo::PrepareAttachmentGizmo(GTAentity& parentEntity, GTAentity& attachedEntity, Vector3& localOffset, int boneIndex)
+{
+	SET_MOUSE_CURSOR_VISIBLE(true);
+	SET_MOUSE_CURSOR_THIS_FRAME();
+
+	Vector3 worldPos;
+	if (boneIndex >= 0)
+	{
+		worldPos = attachedEntity.GetPosition();
+	}
+	else
+	{
+		worldPos = parentEntity.GetOffsetInWorldCoords(localOffset);
+	}
+
+	Vector2 entityScreen;
+	bool entityOnScreen = World::WorldToScreen(worldPos, entityScreen);
+
+	frame.ComputeForEntity(attachedEntity, worldPos);
+	frame.ComputeAxisScreenProjections(worldPos, entityScreen, entityOnScreen);
+
+	drag.hoveredAxis = FindAxisAtCursor(GetCursorPos());
+
+	Draw(worldPos);
+
+	if (IS_DISABLED_CONTROL_PRESSED(2, INPUT_CURSOR_ACCEPT))
+	{
+		if (drag.activeAxis == GizmoAxis::None && drag.hoveredAxis != GizmoAxis::None)
+		{
+			drag.activeAxis = drag.hoveredAxis;
+			drag.lastCursorPos = GetCursorPos();
+			drag.dragStartWorldPos = worldPos;
+			drag.accumulatedDelta = Vector3::Zero();
+
+			if (boneIndex >= 0)
+			{
+				drag.boneIndex = boneIndex;
+				drag.initialBoneRelativeOffset = localOffset;
+			}
+		}
+	}
+	else
+	{
+		drag.activeAxis = GizmoAxis::None;
+		drag.boneIndex = -1;
+	}
+
+	return worldPos;
+}
+
+void TransformGizmo::ProcessAttachmentDrag(GTAentity& parentEntity, const Vector3& worldPos, Vector3& localOffset, Vector3& localRot)
+{
+	if (!drag.IsActive())
+		return;
+
+	Vector2 cursorPos = GetCursorPos();
+	Vector2 delta = cursorPos - drag.lastCursorPos;
+	drag.lastCursorPos = cursorPos;
+
+	if (delta.Length() <= ATTACHMENT_DEADZONE)
+		return;
+
+	if (mode == GizmoMode::Translate)
+	{
+		int idx = AxisIndex(drag.activeAxis);
+		Vector2 screenDir = frame.axisScreenProjections[idx];
+		float movement = delta.x * screenDir.x + delta.y * screenDir.y;
+		movement *= GetDistanceBasedSensitivity() * GetAxisScale(GizmoAxis::None);
+
+		drag.accumulatedDelta = drag.accumulatedDelta + GetLocalAxis(drag.activeAxis) * movement;
+		Vector3 newWorldPos = drag.dragStartWorldPos + drag.accumulatedDelta;
+
+		if (drag.boneIndex >= 0)
+		{
+			Vector3 currentBoneRot = GET_ENTITY_BONE_ROTATION(parentEntity.GetHandle(), drag.boneIndex);
+			localOffset = drag.initialBoneRelativeOffset + WorldToBoneRelative(drag.accumulatedDelta, currentBoneRot);
+		}
+		else
+		{
+			localOffset = parentEntity.GetOffsetGivenWorldCoords(newWorldPos);
+		}
+	}
+	else if (mode == GizmoMode::Rotate)
+	{
+		ApplyRotationDelta(localRot, drag.activeAxis, delta);
+	}
+}
+
+void TransformGizmo::ApplyAttachmentMovement(GTAentity& parentEntity, GTAentity& attachedEntity, Vector3& localOffset, Vector3& localRot, int boneIndex)
+{
+	Vector3 worldPos = PrepareAttachmentGizmo(parentEntity, attachedEntity, localOffset, boneIndex);
+	ProcessAttachmentDrag(parentEntity, worldPos, localOffset, localRot);
+}
+
+GizmoAxis TransformGizmo::FindAxisAtCursor(const Vector2& cursorPos) const
+{
+	GizmoAxis closest = GizmoAxis::None;
+	float closestDist = HANDLE_PICK_RADIUS;
+
+	for (int i = 0; i < 3; i++)
+	{
+		if (frame.handlePositions[i].isOnScreen)
+		{
+			float dist = cursorPos.DistanceTo(frame.handlePositions[i].screenPos);
+			if (dist < closestDist)
+			{
+				closestDist = dist;
+				closest = static_cast<GizmoAxis>(i + 1);
+			}
+		}
+	}
+
+	return closest;
+}
+
+void TransformGizmo::DrawAxisLine(const Vector3& origin, const Vector3& direction, float length, const RGBA& colour)
+{
+	Vector3 end = origin + direction * length;
+	World::DrawLine(origin, end, colour);
+}
+
+void TransformGizmo::DrawHandleLabel(GizmoAxis axis, const RGBA& rectColour, int textAlpha, const char* label)
+{
+	int idx = static_cast<int>(axis) - 1;
+	const auto& info = frame.handlePositions[idx];
+	if (!info.isOnScreen)
+		return;
+
+	DRAW_RECT(info.screenPos.x, info.screenPos.y, LABEL_RECT_W, LABEL_RECT_H, rectColour.R, rectColour.G, rectColour.B, rectColour.A, false);
+
+	Game::Print::SetupDraw(GTAfont::Arial, { 0.225f, 0.225f }, true, false, true, { 255, 255, 255, textAlpha });
+	Game::Print::drawstring(label, info.screenPos.x, info.screenPos.y - LABEL_Y_OFFSET);
+}
+
+void TransformGizmo::Draw(const Vector3& entityPos)
+{
+	struct AxisColors { RGBA colour; GizmoAxis axis; };
+	AxisColors axes[] = {
+		{ RGBA(220, 40, 40, 0), GizmoAxis::X },
+		{ RGBA(40, 200, 40, 0), GizmoAxis::Y },
+		{ RGBA(40, 80, 220, 0), GizmoAxis::Z }
+	};
+
+	for (const auto& ac : axes)
+	{
+		int alpha, textAlpha;
+
+		if (ac.axis == drag.activeAxis)
+		{
+			alpha = 255; textAlpha = 255;
+		}
+		else if (ac.axis == drag.hoveredAxis)
+		{
+			alpha = 220; textAlpha = 255;
+		}
+		else
+		{
+			alpha = 180; textAlpha = 200;
+		}
+
+		RGBA axisColour(ac.colour.R, ac.colour.G, ac.colour.B, alpha);
+
+		Vector3 dir = GetLocalAxis(ac.axis);
+		DrawAxisLine(entityPos, dir, frame.axisScales[static_cast<int>(ac.axis) - 1], axisColour);
+		DrawHandleLabel(ac.axis, axisColour, textAlpha, GetAxisLabel(ac.axis));
+	}
+}

--- a/Solution/source/Submenus/Spooner/TransformGizmo.cpp
+++ b/Solution/source/Submenus/Spooner/TransformGizmo.cpp
@@ -10,6 +10,7 @@
 #include "TransformGizmo.h"
 
 #include "..\..\Natives\natives2.h"
+#include "..\..\Natives\natives.h"
 #include "..\..\Scripting\World.h"
 #include "..\..\Scripting\GameplayCamera.h"
 #include "..\..\Scripting\Game.h"
@@ -53,18 +54,12 @@ void TransformGizmo::FrameData::ComputeForEntity(GTAentity& entity, const Vector
 {
 	distanceToEntity = GameplayCamera::GetPosition().DistanceTo(worldPos);
 
-	Vector3 rotation = entity.Rotation_get();
-	float yaw = DegreeToRadian(rotation.z);
-	float pitch = DegreeToRadian(rotation.y);
-	float roll = DegreeToRadian(rotation.x);
+	Vector3_t forward_t, right_t, up_t, pos_t;
+	GET_ENTITY_MATRIX(entity.GetHandle(), &forward_t, &right_t, &up_t, &pos_t);
 
-	float cY = std::cos(yaw), sY = std::sin(yaw);
-	float cP = std::cos(pitch), sP = std::sin(pitch);
-	float cR = std::cos(roll), sR = std::sin(roll);
-
-	localAxes[0] = Vector3(cY * cP, sY * cP, -sP);
-	localAxes[1] = Vector3(-sY * cR + cY * sP * sR, cY * cR + sY * sP * sR, cP * sR);
-	localAxes[2] = Vector3(sY * sR + cY * sP * cR, -cY * sR + sY * sP * cR, cP * cR);
+	localAxes[0] = Vector3(right_t);
+	localAxes[1] = -Vector3(forward_t);
+	localAxes[2] = Vector3(up_t);
 
 	auto dims = entity.ModelDimensions();
 	float halfX = std::abs(dims.Dim2.x - dims.Dim1.x) * 0.5f;
@@ -165,13 +160,13 @@ Vector3 TransformGizmo::WorldToBoneRelative(const Vector3& worldOffset, const Ve
 	float pitch = DegreeToRadian(boneRotEuler.y);
 	float roll = DegreeToRadian(boneRotEuler.x);
 
-	float cY = std::cos(yaw), sY = std::sin(yaw);
-	float cP = std::cos(pitch), sP = std::sin(pitch);
-	float cR = std::cos(roll), sR = std::sin(roll);
+	float cZ = std::cos(yaw), sZ = std::sin(yaw);
+	float cX = std::cos(roll), sX = std::sin(roll);
+	float cY = std::cos(pitch), sY = std::sin(pitch);
 
-	Vector3 xAxis(cY * cP, sY * cP, -sP);
-	Vector3 yAxis(-sY * cR + cY * sP * sR, cY * cR + sY * sP * sR, cP * sR);
-	Vector3 zAxis(sY * sR + cY * sP * cR, -cY * sR + sY * sP * cR, cP * cR);
+	Vector3 xAxis = Vector3(cZ * cY - sZ * sX * sY, sZ * cY + cZ * sX * sY, -cX * sY);
+	Vector3 yAxis = Vector3(-sZ * cX, cZ * cX, sX);
+	Vector3 zAxis = Vector3(cZ * sY + sZ * sX * cY, sZ * sY - cZ * sX * cY, cX * cY);
 
 	return Vector3(
 		Vector3::Dot(worldOffset, xAxis),

--- a/Solution/source/Submenus/Spooner/TransformGizmo.h
+++ b/Solution/source/Submenus/Spooner/TransformGizmo.h
@@ -1,0 +1,92 @@
+/*
+* Menyoo PC - Grand Theft Auto V single-player trainer mod
+* Copyright (C) 2019  MAFINS
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*/
+#pragma once
+
+#include "..\..\Util\GTAmath.h"
+
+class GTAentity;
+class RGBA;
+
+enum class GizmoMode { Translate, Rotate };
+enum class GizmoAxis { None, X, Y, Z };
+
+class TransformGizmo
+{
+public:
+	TransformGizmo();
+
+	void Draw(const Vector3& entityPos);
+	void Update();
+	void ApplyMovement(GTAentity& entity);
+
+	GizmoAxis GetActiveAxis() const;
+	GizmoMode GetMode() const;
+	void SetMode(GizmoMode mode);
+	bool IsActive() const;
+
+	void ApplyAttachmentMovement(GTAentity& parentEntity, GTAentity& attachedEntity, Vector3& localOffset, Vector3& localRot, int boneIndex = -1);
+
+private:
+	struct HandleScreenInfo
+	{
+		bool isOnScreen;
+		Vector2 screenPos;
+	};
+
+	struct FrameData
+	{
+		HandleScreenInfo handlePositions[3];
+		Vector2 axisScreenProjections[3];
+		float axisScales[3] = {1.0f, 1.0f, 1.0f};
+		Vector3 localAxes[3];
+		float distanceToEntity = 0.0f;
+
+		void ComputeForEntity(GTAentity& entity, const Vector3& worldPos);
+		void ComputeAxisScreenProjections(const Vector3& worldPos, const Vector2& entityScreenPos, bool entityOnScreen);
+	};
+
+	struct DragContext
+	{
+		GizmoAxis activeAxis = GizmoAxis::None;
+		GizmoAxis hoveredAxis = GizmoAxis::None;
+		Vector2 startCursorPos = Vector2::Zero();
+		Vector2 lastCursorPos = Vector2::Zero();
+		Vector3 startPos = Vector3::Zero();
+		Vector3 startRotation = Vector3::Zero();
+		Vector3 accumulatedDelta = Vector3::Zero();
+		Vector3 dragStartWorldPos = Vector3::Zero();
+		int boneIndex = -1;
+		Vector3 initialBoneRelativeOffset = Vector3::Zero();
+
+		void Reset() { *this = DragContext(); }
+		bool IsActive() const { return activeAxis != GizmoAxis::None; }
+	};
+
+	GizmoMode mode;
+	DragContext drag;
+	FrameData frame;
+
+	Vector3 GetLocalAxis(GizmoAxis axis) const;
+	float GetAxisScale(GizmoAxis axis) const;
+	float GetDistanceBasedSensitivity() const;
+	int AxisIndex(GizmoAxis axis) const;
+	const char* GetAxisLabel(GizmoAxis axis) const;
+	Vector2 GetCursorPos() const;
+	float NormalizeAngle(float angle);
+	void ApplyRotationDelta(Vector3& rotation, GizmoAxis axis, const Vector2& delta);
+	Vector3 WorldToBoneRelative(const Vector3& worldOffset, const Vector3& boneRotEuler) const;
+
+	GizmoAxis FindAxisAtCursor(const Vector2& cursorPos) const;
+	void DrawAxisLine(const Vector3& origin, const Vector3& direction, float length, const RGBA& colour);
+	void DrawHandleLabel(GizmoAxis axis, const RGBA& rectColour, int textAlpha, const char* label);
+
+	Vector3 PrepareAttachmentGizmo(GTAentity& parentEntity, GTAentity& attachedEntity, Vector3& localOffset, int boneIndex = -1);
+	void ProcessAttachmentDrag(GTAentity& parentEntity, const Vector3& worldPos, Vector3& localOffset, Vector3& localRot);
+};

--- a/Solution/source/Util/GTAmath.cpp
+++ b/Solution/source/Util/GTAmath.cpp
@@ -765,6 +765,13 @@ Vector3 DegreeToRadian(const Vector3& angles)
 {
 	return Vector3(angles.x * 0.0174532925199433F, angles.y * 0.0174532925199433F, angles.z * 0.0174532925199433F);
 }
+
+void WrapAngle(float& angle)
+{
+	while (angle > 180.0f) angle -= 360.0f;
+	while (angle < -180.0f) angle += 360.0f;
+}
+
 float GetHeadingFromCoords(const Vector3& source, const Vector3& target)
 {
 	return atan2((target.y - source.y), (target.x - source.x));

--- a/Solution/source/Util/GTAmath.h
+++ b/Solution/source/Util/GTAmath.h
@@ -871,6 +871,7 @@ float get_random_float_in_range(float min, float max);
 
 float DegreeToRadian(float angle);
 float RadianToDegree(float angle);
+void WrapAngle(float& angle);
 
 Vector3 DegreeToRadian(const Vector3& angles);
 float GetHeadingFromCoords(const Vector3& source, const Vector3& target);


### PR DESCRIPTION
This PR adds yet another entity position / rotation manipulation method - a gizmo. It basically allows the user to drag their mouse along the X/Y/Z axis of the entity to move or rotate it.

I have been testing it for a few days and everything seems to work fine. Only problem is a gimbal lock occuring when pitch > 90, but that's been a long-standing problem with Menyoo and would require refactoring huge portions of code handling rotations to use quaternions instead of euler angles.

Preview video showcasing the feature: https://streamable.com/g8nn8a