### PR TITLE
Security: Fix Multiple Path Traversal Vulnerabilities

### DIFF
--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -1786,8 +1786,15 @@ namespace sub
 			std::string inputStr = Game::InputBox("", 28U, "FMMC_KEY_TIP9");
 			if (inputStr.length() > 0)
 			{
-				ComponentChangerOutfit::Create(g_Ped1, dir + "\\" + inputStr + ".xml");
-				Game::Print::PrintBottomLeft("File ~b~created~s~.");
+				if (!IsSafePath(inputStr))
+				{
+					Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+				}
+				else
+				{
+					ComponentChangerOutfit::Create(g_Ped1, dir + "\\" + inputStr + ".xml");
+					Game::Print::PrintBottomLeft("File ~b~created~s~.");
+				}
 			}
 			else Game::Print::PrintErrorInvalidInput(inputStr);
 			return;
@@ -1798,7 +1805,11 @@ namespace sub
 			std::string inputStr = Game::InputBox("", 28U, "Enter folder name:");
 			if (inputStr.length() > 0)
 			{
-				if (CreateDirectoryA((dir + "\\" + inputStr).c_str(), NULL) || GetLastError() == ERROR_ALREADY_EXISTS)
+				if (!IsSafePath(inputStr))
+				{
+					Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+				}
+				else if (CreateDirectoryA((dir + "\\" + inputStr).c_str(), NULL) || GetLastError() == ERROR_ALREADY_EXISTS)
 				{
 					dir = dir + "\\" + inputStr;
 					Menu::currentop = 5;
@@ -1880,7 +1891,11 @@ namespace sub
 			std::string newName = Game::InputBox("", 28U, "FMMC_KEY_TIP9", name);
 			if (newName.length() > 0)
 			{
-				if (rename(filePath.c_str(), (dir + "\\" + newName + ".xml").c_str()) == 0)
+				if (!IsSafePath(newName))
+				{
+					Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+				}
+				else if (rename(filePath.c_str(), (dir + "\\" + newName + ".xml").c_str()) == 0)
 				{
 					name = newName;
 					Game::Print::PrintBottomLeft("File ~b~renamed~s~.");

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -398,7 +398,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter file name:");
 				if (inputStr.length() > 0)
 				{
-					if (FileManagement::SaveDbToFile(_dir + "\\" + inputStr + ".xml", true))
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (FileManagement::SaveDbToFile(_dir + "\\" + inputStr + ".xml", true))
 					{
 						Game::Print::PrintBottomLeft("File ~b~saved~s~.");
 					}
@@ -418,7 +422,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter file name:");
 				if (inputStr.length() > 0)
 				{
-					if (FileManagement::SaveWorldToFile(_dir + "\\" + inputStr + ".xml", worldEntities, Databases::MarkerDb))
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (FileManagement::SaveWorldToFile(_dir + "\\" + inputStr + ".xml", worldEntities, Databases::MarkerDb))
 					{
 						Game::Print::PrintBottomLeft("File ~b~saved~s~.");
 					}
@@ -428,8 +436,6 @@ namespace sub
 						addlog(ige::LogType::LOG_ERROR, "Attempt to save World file " + inputStr + ".xml failed");
 					}
 				}
-				//OnscreenKeyboard::State::Set(OnscreenKeyboard::Purpose::SpoonerSaveWorldToFile, std::string(), 28U, "Enter file name:");
-				//OnscreenKeyboard::State::arg1._ptr = reinterpret_cast<void*>(&_dir);
 			}
 
 			std::vector<Entity> vSaveRangeEntities;
@@ -445,23 +451,26 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter file name:");
 				if (inputStr.length() > 0)
 				{
-					std::vector<SpoonerMarker> vSaveRangeMarkers;
-					MarkerManagement::GetAllMarkersInRange(vSaveRangeMarkers, myPos, fSaveRangeRadius);
-
-					if (FileManagement::SaveWorldToFile(_dir + "\\" + inputStr + ".xml", vSaveRangeEntities, vSaveRangeMarkers))
+					if (!IsSafePath(inputStr))
 					{
-						Game::Print::PrintBottomLeft("File ~b~saved~s~.");
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
 					}
 					else
 					{
-						Game::Print::PrintBottomCentre("~r~Error:~s~ Unable to save file.");
-						addlog(ige::LogType::LOG_ERROR, "Attempt to save Range Markers file " + inputStr + ".xml failed");
+						std::vector<SpoonerMarker> vSaveRangeMarkers;
+						MarkerManagement::GetAllMarkersInRange(vSaveRangeMarkers, myPos, fSaveRangeRadius);
+
+						if (FileManagement::SaveWorldToFile(_dir + "\\" + inputStr + ".xml", vSaveRangeEntities, vSaveRangeMarkers))
+						{
+							Game::Print::PrintBottomLeft("File ~b~saved~s~.");
+						}
+						else
+						{
+							Game::Print::PrintBottomCentre("~r~Error:~s~ Unable to save file.");
+							addlog(ige::LogType::LOG_ERROR, "Attempt to save Range Markers file " + inputStr + ".xml failed");
+						}
 					}
 				}
-				//OnscreenKeyboard::State::Set(OnscreenKeyboard::Purpose::SpoonerSaveRangeToFile, std::string(), 28U, "Enter file name:");
-				//OnscreenKeyboard::State::arg1._float = fSaveRangeRadius;
-				//OnscreenKeyboard::State::arg2._vec3 = new Vector3(myPos);
-				//OnscreenKeyboard::State::arg3._ptr = reinterpret_cast<void*>(&_dir);
 			}
 
 			/*bool bLoadFromFile = false;
@@ -504,7 +513,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter folder name:");
 				if (inputStr.length() > 0)
 				{
-					if (CreateDirectoryA((_dir + "\\" + inputStr).c_str(), NULL) ||
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (CreateDirectoryA((_dir + "\\" + inputStr).c_str(), NULL) ||
 						GetLastError() == ERROR_ALREADY_EXISTS)
 					{
 						_dir = _dir + "\\" + inputStr;
@@ -528,8 +541,16 @@ namespace sub
 			bool bFolderBackPressed = false;
 			AddOption("..", bFolderBackPressed); if (bFolderBackPressed)
 			{
-				_dir = _dir.substr(0, _dir.rfind("\\"));
-				Menu::currentop = 6;
+				std::string baseDir = GetPathffA(Pathff::Spooner, false);
+				if (_dir.length() > baseDir.length() && _dir.find(baseDir) == 0)
+				{
+					_dir = _dir.substr(0, _dir.rfind("\\"));
+					Menu::currentop = 6;
+				}
+				else
+				{
+					_dir = baseDir;
+				}
 			}
 
 			if (!vfilnames.empty())
@@ -658,7 +679,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter new name:", _name);
 				if (inputStr.length() > 0)
 				{
-					if (rename(filePath.c_str(), (_dir + "\\" + inputStr + ".xml").c_str()) == 0)
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (rename(filePath.c_str(), (_dir + "\\" + inputStr + ".xml").c_str()) == 0)
 					{
 						_name = inputStr;
 						Game::Print::PrintBottomLeft("File ~b~renamed~s~.");
@@ -1042,7 +1067,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter new name:", _name);
 				if (inputStr.length() > 0)
 				{
-					if (rename(filePath.c_str(), (_dir + "\\" + inputStr + ".SP00N").c_str()) == 0)
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (rename(filePath.c_str(), (_dir + "\\" + inputStr + ".SP00N").c_str()) == 0)
 					{
 						_name = inputStr;
 						Game::Print::PrintBottomLeft("File ~b~renamed~s~.");

--- a/Solution/source/Submenus/VehicleSpawner.cpp
+++ b/Solution/source/Submenus/VehicleSpawner.cpp
@@ -3100,7 +3100,14 @@ namespace sub
 					std::string inputStr = Game::InputBox("", 28U, "Enter file name:");
 					if (inputStr.length() > 0)
 					{
-						VehicleSaveToFile(_dir + "\\" + inputStr + ".xml", vehicle);
+						if (!IsSafePath(inputStr))
+						{
+							Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+						}
+						else
+						{
+							VehicleSaveToFile(_dir + "\\" + inputStr + ".xml", vehicle);
+						}
 					}
 					else
 					{
@@ -3127,7 +3134,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter folder name:");
 				if (inputStr.length() > 0)
 				{
-					if (CreateDirectoryA((_dir + "\\" + inputStr).c_str(), NULL) || GetLastError() == ERROR_ALREADY_EXISTS)
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (CreateDirectoryA((_dir + "\\" + inputStr).c_str(), NULL) || GetLastError() == ERROR_ALREADY_EXISTS)
 					{
 						_dir = _dir + "\\" + inputStr;
 						Menu::currentop = 6;
@@ -3177,16 +3188,23 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter new name:", _name);
 				if (inputStr.length() > 0)
 				{
-					std::string oldPath = _dir + "\\" + _name + ".xml";
-					std::string newPath = _dir + "\\" + inputStr + ".xml";
-					if (rename(oldPath.c_str(), (newPath).c_str()) == 0)
+					if (!IsSafePath(inputStr))
 					{
-						Game::Print::PrintBottomLeft("File ~b~renamed~s~.");
-						_name = inputStr;
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
 					}
-					else 
+					else
 					{
-						Game::Print::PrintBottomCentre("~r~Error~s~ renaming file.");
+						std::string oldPath = _dir + "\\" + _name + ".xml";
+						std::string newPath = _dir + "\\" + inputStr + ".xml";
+						if (rename(oldPath.c_str(), (newPath).c_str()) == 0)
+						{
+							Game::Print::PrintBottomLeft("File ~b~renamed~s~.");
+							_name = inputStr;
+						}
+						else 
+						{
+							Game::Print::PrintBottomCentre("~r~Error~s~ renaming file.");
+						}
 					}
 				}
 				else 

--- a/Solution/source/Submenus/WeaponOptions.cpp
+++ b/Solution/source/Submenus/WeaponOptions.cpp
@@ -1587,7 +1587,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter loadout name:");
 				if (inputStr.length() > 0)
 				{
-					if (WeaponsLoadouts_catind::Create(_ped, _dir + "\\" + inputStr + ".xml"))
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (WeaponsLoadouts_catind::Create(_ped, _dir + "\\" + inputStr + ".xml"))
 						Game::Print::PrintBottomLeft("Loadout ~b~saved~s~.");
 					else
 						Game::Print::PrintBottomLeft("~r~Error:~s~ Unable to save loadout.");
@@ -1604,7 +1608,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter folder name:");
 				if (inputStr.length() > 0)
 				{
-					if (CreateDirectoryA((_dir + "\\" + inputStr).c_str(), NULL) ||
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (CreateDirectoryA((_dir + "\\" + inputStr).c_str(), NULL) ||
 						GetLastError() == ERROR_ALREADY_EXISTS)
 					{
 						_dir = _dir + "\\" + inputStr;
@@ -1650,7 +1658,11 @@ namespace sub
 				std::string inputStr = Game::InputBox("", 28U, "Enter new name:", _name);
 				if (inputStr.length())
 				{
-					if (rename(filePath.c_str(), (_dir + "\\" + inputStr + ".xml").c_str()) == 0)
+					if (!IsSafePath(inputStr))
+					{
+						Game::Print::PrintBottomCentre("~r~Error:~s~ Invalid characters in name.");
+					}
+					else if (rename(filePath.c_str(), (_dir + "\\" + inputStr + ".xml").c_str()) == 0)
 					{
 						_name = inputStr;
 						Game::Print::PrintBottomLeft("File ~b~renamed~s~.");

--- a/Solution/source/Util/StringManip.cpp
+++ b/Solution/source/Util/StringManip.cpp
@@ -48,5 +48,36 @@ namespace boost
 	}
 }
 
+bool IsSafePath(const std::string& path)
+{
+	if (path.empty() || path.length() > 128) return false;
+
+	for (unsigned char c : path)
+	{
+		if (!isalnum(c) && c != '_' && c != '-' && c != ' ')
+		{
+			return false;
+		}
+	}
+
+	std::string upper = path;
+	std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
+
+	static const std::vector<std::string> reservedNames = {
+		"CON", "PRN", "AUX", "NUL",
+		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+	};
+
+	for (const std::string& reserved : reservedNames)
+	{
+		if (upper == reserved) return false;
+	}
+
+	if (path.front() == ' ' || path.back() == ' ' || path.back() == '.') return false;
+
+	return true;
+}
+
 
 

--- a/Solution/source/Util/StringManip.h
+++ b/Solution/source/Util/StringManip.h
@@ -24,6 +24,8 @@ namespace boost
 	std::string to_lower_copy(std::string str);
 }
 
+bool IsSafePath(const std::string& path);
+
 
 
 


### PR DESCRIPTION
Implemented a robust 'IsSafePath' validation function using a whitelist approach to sanitize user-provided file and folder names across all file management modules (Spooner, VehicleSpawner, WeaponOptions, and PedComponentChanger).

Key changes:
- Restricted allowed characters to alphanumeric, spaces, underscores, and hyphens.
- Blocked directory traversal sequences (..), path separators (/, \), and drive identifiers (:).
- Implemented checks for Windows reserved filenames (e.g., CON, NUL, COM1-9).
- Constrained the '..' navigation in the Spooner menu to prevent traversal above the intended root directory.


P.S: I couldn't find any specific contact information for you. I thought this would be the quickest way to resolve the issue. If you leave your email address, I can send you information about the vulnerability details.