### PR TITLE
Animation saving overhaul

### DIFF
--- a/Solution/source/Submenus/PedAnimation.cpp
+++ b/Solution/source/Submenus/PedAnimation.cpp
@@ -336,8 +336,18 @@ namespace sub
 			if (spi >= 0)
 			{
 				auto& spe = sub::Spooner::Databases::EntityDb[spi];
-				spe.lastAnimation.dict = animDict;
-				spe.lastAnimation.name = animName;
+				{
+					sub::Spooner::SpoonerEntity::Animation animData;
+					animData.dict = animDict;
+					animData.name = animName;
+					animData.speed = g_customAnimSpeed;
+					animData.speedMultiplier = g_customAnimSpeedMult;
+					animData.playbackRate = g_CustomAnimRate;
+					animData.duration = g_customAnimDuration;
+					animData.flag = g_customAnimFlag;
+					animData.lockPos = g_customAnimLockPos;
+					spe.AddOrUpdateLastAnimation(animData);
+				}
 				if (att.Exists() && spe.attachmentArgs.isAttached)
 				{
 					spe.handle.AttachTo(att, spe.attachmentArgs.boneIndex, spe.handle.GetIsCollisionEnabled(), spe.attachmentArgs.offset, spe.attachmentArgs.rotation);
@@ -345,8 +355,7 @@ namespace sub
 				spe.taskSequence.Reset();
 				if (sub::Spooner::selectedEntity.handle.Equals(spe.handle))
 				{
-					sub::Spooner::selectedEntity.lastAnimation.dict = spe.lastAnimation.dict;
-					sub::Spooner::selectedEntity.lastAnimation.name = spe.lastAnimation.name;
+					sub::Spooner::selectedEntity.lastAnimations = spe.lastAnimations;
 					sub::Spooner::selectedEntity.taskSequence = spe.taskSequence;
 				}
 			}
@@ -402,8 +411,7 @@ namespace sub
 		if (spi >= 0)
 		{
 			auto& spe = sub::Spooner::Databases::EntityDb[spi];
-			spe.lastAnimation.dict.clear();
-			spe.lastAnimation.name.clear();
+			spe.ClearLastAnimations();
 			if (att.Exists() && spe.attachmentArgs.isAttached)
 			{
 				spe.handle.AttachTo(att, spe.attachmentArgs.boneIndex, spe.handle.GetIsCollisionEnabled(), spe.attachmentArgs.offset, spe.attachmentArgs.rotation);
@@ -411,8 +419,7 @@ namespace sub
 			spe.taskSequence.Reset();
 			if (sub::Spooner::selectedEntity.handle.Equals(spe.handle))
 			{
-				sub::Spooner::selectedEntity.lastAnimation.dict = spe.lastAnimation.dict;
-				sub::Spooner::selectedEntity.lastAnimation.name = spe.lastAnimation.name;
+				sub::Spooner::selectedEntity.lastAnimations = spe.lastAnimations;
 				sub::Spooner::selectedEntity.taskSequence = spe.taskSequence;
 			}
 		}
@@ -876,8 +883,16 @@ namespace sub
 			if (spi >= 0)
 			{
 				auto& spe = sub::Spooner::Databases::EntityDb[spi];
-				spe.lastAnimation.dict = sub_animDict;
-				spe.lastAnimation.name = sub_animName;
+				sub::Spooner::SpoonerEntity::Animation animData;
+				animData.dict = sub_animDict;
+				animData.name = sub_animName;
+				animData.speed = g_customAnimSpeed;
+				animData.speedMultiplier = g_customAnimSpeedMult;
+				animData.playbackRate = g_CustomAnimRate;
+				animData.duration = g_customAnimDuration;
+				animData.flag = g_customAnimFlag;
+				animData.lockPos = g_customAnimLockPos;
+				spe.AddOrUpdateLastAnimation(animData);
 				if (att.Exists() && spe.attachmentArgs.isAttached)
 				{
 					spe.handle.AttachTo(att, spe.attachmentArgs.boneIndex, spe.handle.GetIsCollisionEnabled(), spe.attachmentArgs.offset, spe.attachmentArgs.rotation);
@@ -885,8 +900,7 @@ namespace sub
 				spe.taskSequence.Reset();
 				if (sub::Spooner::selectedEntity.handle.Equals(spe.handle))
 				{
-					sub::Spooner::selectedEntity.lastAnimation.dict = spe.lastAnimation.dict;
-					sub::Spooner::selectedEntity.lastAnimation.name = spe.lastAnimation.name;
+					sub::Spooner::selectedEntity.lastAnimations = spe.lastAnimations;
 					sub::Spooner::selectedEntity.taskSequence = spe.taskSequence;
 				}
 			}
@@ -920,8 +934,7 @@ namespace sub
 			if (spi >= 0)
 			{
 				auto& spe = sub::Spooner::Databases::EntityDb[spi];
-				spe.lastAnimation.dict.clear();
-				spe.lastAnimation.name.clear();
+				spe.ClearLastAnimations();
 				if (att.Exists() && spe.attachmentArgs.isAttached)
 				{
 					spe.handle.AttachTo(att, spe.attachmentArgs.boneIndex, spe.handle.GetIsCollisionEnabled(), spe.attachmentArgs.offset, spe.attachmentArgs.rotation);
@@ -929,8 +942,7 @@ namespace sub
 				spe.taskSequence.Reset();
 				if (sub::Spooner::selectedEntity.handle.Equals(spe.handle))
 				{
-					sub::Spooner::selectedEntity.lastAnimation.dict = spe.lastAnimation.dict;
-					sub::Spooner::selectedEntity.lastAnimation.name = spe.lastAnimation.name;
+					sub::Spooner::selectedEntity.lastAnimations = spe.lastAnimations;
 					sub::Spooner::selectedEntity.taskSequence = spe.taskSequence;
 				}
 			}
@@ -1286,8 +1298,8 @@ namespace sub
 				if (spi >= 0)
 				{
 					auto& spe = sub::Spooner::Databases::EntityDb[spi];
-					spe.lastAnimation.dict.clear();
-					spe.lastAnimation.name = scenarioLabel;
+					spe.ClearLastAnimations();
+					spe.currentScenario = scenarioLabel;
 					if (att.Exists() && spe.attachmentArgs.isAttached)
 					{
 						spe.handle.AttachTo(att, spe.attachmentArgs.boneIndex, spe.handle.GetIsCollisionEnabled(), spe.attachmentArgs.offset, spe.attachmentArgs.rotation);
@@ -1295,8 +1307,8 @@ namespace sub
 					spe.taskSequence.Reset();
 					if (sub::Spooner::selectedEntity.handle.Equals(spe.handle))
 					{
-						sub::Spooner::selectedEntity.lastAnimation.dict = spe.lastAnimation.dict;
-						sub::Spooner::selectedEntity.lastAnimation.name = spe.lastAnimation.name;
+						sub::Spooner::selectedEntity.lastAnimations = spe.lastAnimations;
+						sub::Spooner::selectedEntity.currentScenario = spe.currentScenario;
 						sub::Spooner::selectedEntity.taskSequence = spe.taskSequence;
 					}
 				}
@@ -1331,8 +1343,8 @@ namespace sub
 			if (spi >= 0)
 			{
 				auto& spe = sub::Spooner::Databases::EntityDb[spi];
-				spe.lastAnimation.dict.clear();
-				spe.lastAnimation.name.clear();
+				spe.ClearLastAnimations();
+				spe.currentScenario.clear();
 				if (att.Exists() && spe.attachmentArgs.isAttached)
 				{
 					spe.handle.AttachTo(att, spe.attachmentArgs.boneIndex, spe.handle.GetIsCollisionEnabled(), spe.attachmentArgs.offset, spe.attachmentArgs.rotation);
@@ -1340,8 +1352,8 @@ namespace sub
 				spe.taskSequence.Reset();
 				if (sub::Spooner::selectedEntity.handle.Equals(spe.handle))
 				{
-					sub::Spooner::selectedEntity.lastAnimation.dict = spe.lastAnimation.dict;
-					sub::Spooner::selectedEntity.lastAnimation.name = spe.lastAnimation.name;
+					sub::Spooner::selectedEntity.lastAnimations = spe.lastAnimations;
+					sub::Spooner::selectedEntity.currentScenario = spe.currentScenario;
 					sub::Spooner::selectedEntity.taskSequence = spe.taskSequence;
 				}
 			}

--- a/Solution/source/Submenus/PedAnimation.cpp
+++ b/Solution/source/Submenus/PedAnimation.cpp
@@ -336,18 +336,17 @@ namespace sub
 			if (spi >= 0)
 			{
 				auto& spe = sub::Spooner::Databases::EntityDb[spi];
-				{
-					sub::Spooner::SpoonerEntity::Animation animData;
-					animData.dict = animDict;
-					animData.name = animName;
-					animData.speed = g_customAnimSpeed;
-					animData.speedMultiplier = g_customAnimSpeedMult;
-					animData.playbackRate = g_CustomAnimRate;
-					animData.duration = g_customAnimDuration;
-					animData.flag = g_customAnimFlag;
-					animData.lockPos = g_customAnimLockPos;
-					spe.AddOrUpdateLastAnimation(animData);
-				}
+				sub::Spooner::SpoonerEntity::Animation animData;
+				animData.dict = animDict;
+				animData.name = animName;
+				animData.speed = g_customAnimSpeed;
+				animData.speedMultiplier = g_customAnimSpeedMult;
+				animData.playbackRate = g_CustomAnimRate;
+				animData.duration = g_customAnimDuration;
+				animData.flag = g_customAnimFlag;
+				animData.lockPos = g_customAnimLockPos;
+				spe.AddOrUpdateLastAnimation(animData);
+
 				if (att.Exists() && spe.attachmentArgs.isAttached)
 				{
 					spe.handle.AttachTo(att, spe.attachmentArgs.boneIndex, spe.handle.GetIsCollisionEnabled(), spe.attachmentArgs.offset, spe.attachmentArgs.rotation);

--- a/Solution/source/Submenus/PedModelChanger.cpp
+++ b/Solution/source/Submenus/PedModelChanger.cpp
@@ -290,8 +290,8 @@ namespace sub
 					{
 						IntToHexString(model.hash, true);
 					}
-					spe.lastAnimation.dict.clear();
-					spe.lastAnimation.name.clear();
+					spe.ClearLastAnimations();
+					spe.currentScenario.clear();
 					if (att.Exists() && spe.attachmentArgs.isAttached)
 					{
 						spe.handle.AttachTo(att, spe.attachmentArgs.boneIndex, spe.handle.GetIsCollisionEnabled(), spe.attachmentArgs.offset, spe.attachmentArgs.rotation);

--- a/Solution/source/Submenus/Spooner/EntityManagement.cpp
+++ b/Solution/source/Submenus/Spooner/EntityManagement.cpp
@@ -676,14 +676,20 @@ namespace sub::Spooner
 				SET_PED_CAN_PLAY_VISEME_ANIMS(ep.Handle(), true, TRUE);
 				SET_PED_IS_IGNORED_BY_AUTO_OPEN_DOORS(ep.Handle(), true);
 
-				if (!bTaskSeqIsActive && IS_PED_USING_SCENARIO(orig.handle.Handle(), orig.lastAnimation.name.c_str()))
+				if (!bTaskSeqIsActive && !orig.currentScenario.empty() && IS_PED_USING_SCENARIO(orig.handle.Handle(), orig.currentScenario.c_str()))
 				{
 					WAIT(40);
-					ep.Task().StartScenario(orig.lastAnimation.name, -1, false);
+					ep.Task().StartScenario(orig.currentScenario, -1, false);
 				}
-				if (!bTaskSeqIsActive && IS_ENTITY_PLAYING_ANIM(orig.handle.Handle(), orig.lastAnimation.dict.c_str(), orig.lastAnimation.name.c_str(), 3))
+				if (!bTaskSeqIsActive)
 				{
-					ep.Task().PlayAnimation(orig.lastAnimation.dict, orig.lastAnimation.name);
+					for (const auto& anim : orig.lastAnimations)
+					{
+						if (IS_ENTITY_PLAYING_ANIM(orig.handle.Handle(), anim.dict.c_str(), anim.name.c_str(), 3))
+						{
+							ep.Task().PlayAnimation(anim.dict, anim.name, anim.speed, anim.speedMultiplier, anim.duration, anim.flag, anim.playbackRate, anim.lockPos);
+						}
+					}
 				}
 
 				const auto& facialMoodStr = GetPedFacialMood(orig.handle);

--- a/Solution/source/Submenus/Spooner/FileManagement.cpp
+++ b/Solution/source/Submenus/Spooner/FileManagement.cpp
@@ -234,27 +234,36 @@ namespace sub::Spooner
 					nodePedStuff.append_child("WeaponMovementGroupName").text() = wmovGrpIter->second.c_str();
 				}
 
-				bool isUsingScenario = IS_PED_USING_SCENARIO(ep.Handle(), e.lastAnimation.name.c_str()) != 0;
-				bool isPlayingAnim = IS_ENTITY_PLAYING_ANIM(ep.Handle(), e.lastAnimation.dict.c_str(), e.lastAnimation.name.c_str(), 3) != 0;
+				bool isUsingScenario = !e.currentScenario.empty() && IS_PED_USING_SCENARIO(ep.Handle(), e.currentScenario.c_str()) != 0;
 
 				if (isUsingScenario && !(bEntTaskSequenceIsActive && e.taskSequence.ContainsType(STSTaskType::ScenarioAction)))
 				{
 					nodePedStuff.append_child("ScenarioActive").text() = true;
-					nodePedStuff.append_child("ScenarioName").text() = e.lastAnimation.name.c_str();
+					nodePedStuff.append_child("ScenarioName").text() = e.currentScenario.c_str();
 				}
 				else
 				{
 					nodePedStuff.append_child("ScenarioActive").text() = false;
 				}
-				if (isPlayingAnim && !(bEntTaskSequenceIsActive && e.taskSequence.ContainsType(STSTaskType::PlayAnimation)))
+
+				if (!(bEntTaskSequenceIsActive && e.taskSequence.ContainsType(STSTaskType::PlayAnimation)))
 				{
-					nodePedStuff.append_child("AnimActive").text() = true;
-					nodePedStuff.append_child("AnimDict").text() = e.lastAnimation.dict.c_str();
-					nodePedStuff.append_child("AnimName").text() = e.lastAnimation.name.c_str();
-				}
-				else
-				{
-					nodePedStuff.append_child("AnimActive").text() = false;
+					auto nodeAnimations = nodePedStuff.append_child("Animations");
+					for (const auto& anim : e.lastAnimations)
+					{
+						if (IS_ENTITY_PLAYING_ANIM(ep.Handle(), anim.dict.c_str(), anim.name.c_str(), 3))
+						{
+							auto nodeAnim = nodeAnimations.append_child("Animation");
+							nodeAnim.append_child("Dict").text() = anim.dict.c_str();
+							nodeAnim.append_child("Name").text() = anim.name.c_str();
+							nodeAnim.append_child("Speed").text() = anim.speed;
+							nodeAnim.append_child("SpeedMultiplier").text() = anim.speedMultiplier;
+							nodeAnim.append_child("PlaybackRate").text() = anim.playbackRate;
+							nodeAnim.append_child("Duration").text() = anim.duration;
+							nodeAnim.append_child("Flag").text() = anim.flag;
+							nodeAnim.append_child("LockPos").text() = anim.lockPos;
+						}
+					}
 				}
 
 				const auto& facialMoodStr = GetPedFacialMood(ep);
@@ -670,20 +679,53 @@ namespace sub::Spooner
 					FREEZE_ENTITY_POSITION(ep.Handle(), !bFrozenPos);
 				}
 
+				// retained for backwards compatibility, old single-animation format
 				bool isUsingScenario = nodePedStuff.child("ScenarioActive").text().as_bool();
 				bool isUsingAnim = nodePedStuff.child("AnimActive").text().as_bool();
 
 				if (isUsingScenario)
 				{
-					e.e.lastAnimation.name = nodePedStuff.child("ScenarioName").text().as_string();
-					ep.Task().StartScenario(e.e.lastAnimation.name);
+					e.e.currentScenario = nodePedStuff.child("ScenarioName").text().as_string();
+					ep.Task().StartScenario(e.e.currentScenario);
 				}
-				if (isUsingAnim)
+
+				auto nodeAnimations = nodePedStuff.child("Animations");
+				// new format, multiple animations with full parameters
+				if (nodeAnimations)
 				{
-					e.e.lastAnimation.dict = nodePedStuff.child("AnimDict").text().as_string();
-					e.e.lastAnimation.name = nodePedStuff.child("AnimName").text().as_string();
-					Game::RequestAnimDict(e.e.lastAnimation.dict, 1800);
-					ep.Task().PlayAnimation(e.e.lastAnimation.dict, e.e.lastAnimation.name);
+					for (auto nodeAnim = nodeAnimations.first_child(); nodeAnim; nodeAnim = nodeAnim.next_sibling())
+					{
+						SpoonerEntity::Animation animData;
+						animData.dict = nodeAnim.child("Dict").text().as_string();
+						animData.name = nodeAnim.child("Name").text().as_string();
+						animData.speed = nodeAnim.child("Speed").text().as_float(4.0f);
+						animData.speedMultiplier = nodeAnim.child("SpeedMultiplier").text().as_float(-4.0f);
+						animData.playbackRate = nodeAnim.child("PlaybackRate").text().as_float(0.0f);
+						animData.duration = nodeAnim.child("Duration").text().as_int(-1);
+						animData.flag = nodeAnim.child("Flag").text().as_int(AnimFlag::Loop);
+						animData.lockPos = nodeAnim.child("LockPos").text().as_bool(false);
+
+						Game::RequestAnimDict(animData.dict, 1800);
+						ep.Task().PlayAnimation(animData.dict, animData.name, animData.speed, animData.speedMultiplier, animData.duration, animData.flag, animData.playbackRate, animData.lockPos);
+						e.e.AddOrUpdateLastAnimation(animData);
+					}
+				}
+				// old format, single animation with defaults
+				else if (isUsingAnim)
+				{
+					SpoonerEntity::Animation animData;
+					animData.dict = nodePedStuff.child("AnimDict").text().as_string();
+					animData.name = nodePedStuff.child("AnimName").text().as_string();
+					animData.speed = 4.0f;
+					animData.speedMultiplier = -4.0f;
+					animData.playbackRate = 0.0f;
+					animData.duration = -1;
+					animData.flag = AnimFlag::Loop;
+					animData.lockPos = false;
+
+					Game::RequestAnimDict(animData.dict, 1800);
+					ep.Task().PlayAnimation(animData.dict, animData.name);
+					e.e.AddOrUpdateLastAnimation(animData);
 				}
 
 				auto nodeFacialMood = nodePedStuff.child("FacialMood");
@@ -1622,17 +1664,25 @@ namespace sub::Spooner
 							{
 								if (IS_ENTITY_PLAYING_ANIM(e.handle.Handle(), anmnm.animDict.c_str(), anmnm.animName.c_str(), 3))
 								{
-									e.lastAnimation.dict = anmnm.animDict;
-									e.lastAnimation.name = anmnm.animName;
+									SpoonerEntity::Animation anim;
+									anim.dict = anmnm.animDict;
+									anim.name = anmnm.animName;
+									anim.flag = AnimFlag::Loop;
+									anim.speed = 4.0f;
+									anim.speedMultiplier = -4.0f;
+									anim.playbackRate = 0.0f;
+									anim.duration = -1;
+									anim.lockPos = false;
+									e.AddOrUpdateLastAnimation(anim);
 								}
 							}
-							if (e.lastAnimation.dict.empty() && IS_PED_USING_ANY_SCENARIO(e.handle.Handle()))
+							if (IS_PED_USING_ANY_SCENARIO(e.handle.Handle()))
 							{
 								for (auto& scnnm : AnimationTaskScenarios::vValues_TaskScenarios)
 								{
 									if (IS_PED_USING_SCENARIO(e.handle.Handle(), scnnm.c_str()))
 									{
-										e.lastAnimation.name = scnnm;
+										e.currentScenario = scnnm;
 									}
 								}
 							}

--- a/Solution/source/Submenus/Spooner/SpoonerEntity.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerEntity.cpp
@@ -53,8 +53,8 @@ namespace sub::Spooner
 		this->type = (EntityType)right.type;
 		this->hashName = right.hashName;
 		this->dynamic = right.dynamic;
-		this->lastAnimation.dict = right.lastAnimation.dict;
-		this->lastAnimation.name = right.lastAnimation.name;
+		this->lastAnimations = right.lastAnimations;
+		this->currentScenario = right.currentScenario;
 		this->attachmentArgs.isAttached = right.attachmentArgs.isAttached;
 		this->attachmentArgs.boneIndex = right.attachmentArgs.boneIndex;
 		this->attachmentArgs.offset = right.attachmentArgs.offset;
@@ -64,6 +64,39 @@ namespace sub::Spooner
 		this->taskSequence = right.taskSequence;
 
 		//return *this;
+	}
+
+	// helper for automatically removing old animation with the same flag before adding a new one
+	void SpoonerEntity::AddOrUpdateLastAnimation(const Animation& anim)
+	{
+		RemoveFromLastAnimations(anim.flag);
+		lastAnimations.push_back(anim);
+	}
+
+	void SpoonerEntity::RemoveFromLastAnimations(int flag)
+	{
+		for (auto it = lastAnimations.begin(); it != lastAnimations.end(); ++it)
+		{
+			if (it->flag == flag)
+			{
+				lastAnimations.erase(it);
+				return;
+			}
+		}
+	}
+
+	bool SpoonerEntity::HasInLastAnimations(int flag) const
+	{
+		for (const auto& a : lastAnimations)
+		{
+			if (a.flag == flag) return true;
+		}
+		return false;
+	}
+
+	void SpoonerEntity::ClearLastAnimations()
+	{
+		lastAnimations.clear();
 	}
 
 	bool operator == (const SpoonerEntity& left, const SpoonerEntity& right)

--- a/Solution/source/Submenus/Spooner/SpoonerEntity.h
+++ b/Solution/source/Submenus/Spooner/SpoonerEntity.h
@@ -25,7 +25,13 @@ namespace sub::Spooner
 	class SpoonerEntity
 	{
 	public:
-		struct Animation { std::string dict, name; };
+		struct Animation
+		{
+			std::string dict, name;
+			float speed, speedMultiplier, playbackRate;
+			int duration, flag;
+			bool lockPos;
+		};
 		struct Attachment { bool isAttached; int boneIndex; Vector3 offset, rotation; };
 
 		GTAentity handle;
@@ -33,7 +39,8 @@ namespace sub::Spooner
 		std::string hashName;
 		bool dynamic;
 		//bool Door;
-		SpoonerEntity::Animation lastAnimation;
+		std::vector<SpoonerEntity::Animation> lastAnimations;
+		std::string currentScenario;
 		SpoonerEntity::Attachment attachmentArgs;
 		UINT8 textureVariation;
 		bool isStill;
@@ -45,6 +52,11 @@ namespace sub::Spooner
 		SpoonerEntity();
 		//const SpoonerEntity& operator = (const SpoonerEntity& right)
 		SpoonerEntity(const SpoonerEntity& right);
+
+		void AddOrUpdateLastAnimation(const Animation& anim);
+		void RemoveFromLastAnimations(int flag);
+		bool HasInLastAnimations(int flag) const;
+		void ClearLastAnimations();
 
 		friend bool operator == (const SpoonerEntity& left, const SpoonerEntity& right);
 		friend bool operator != (const SpoonerEntity& left, const SpoonerEntity& right);

--- a/Solution/source/Submenus/Spooner/SpoonerMode.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.cpp
@@ -225,8 +225,8 @@ namespace sub::Spooner
 					: get_vehicle_model_label(outEntityModel, true));
 			if (outEntity->hashName.length() == 0) outEntity->hashName = IntToHexString(outEntityModel.hash, true);
 			outEntity->dynamic = !outEntity->handle.IsPositionFrozen();//outEntity->type == EntityType::PED || outEntity->type == EntityType::VEHICLE;
-			//outEntity->lastAnimation.dict.clear();
-			//outEntity->lastAnimation.name.clear();
+			//outEntity->lastAnimations.clear();
+			//outEntity->currentScenario.clear();
 			outEntity->isStill = false;
 
 			auto idInDb = EntityManagement::GetEntityIndexInDb(*outEntity);


### PR DESCRIPTION
This overhauls the animation loading and saving behavior. Previously when we applied two animations to a ped - one with the default "Loop" flag and another with "UpperBody SecondTask Loop" (or any other combination) - Menyoo would save only one of them, and it would be the one that was applied last.  Menyoo also only saved the animation dict and name, so all animations would default to using the "Loop" flag and other default parameters when loaded.

Menyoo now will keep track of what order the animations were added in, save all animation data including animFlag, duration, speed or others and will load them in the right order. This PR also fixes the same issue when copying peds (or other entities), making them properly copy all animations of the original ped instead of just the animation that was applied last.

It will now save this much animation data to .xml files:
```
			<Animations>
				<Animation>
					<Dict>amb@lo_res_idles@</Dict>
					<Name>world_human_lean_male_foot_up_lo_res_base</Name>
					<Speed>4</Speed>
					<SpeedMultiplier>-4</SpeedMultiplier>
					<PlaybackRate>0</PlaybackRate>
					<Duration>-1</Duration>
					<Flag>1</Flag>
					<LockPos>false</LockPos>
				</Animation>
				<Animation>
					<Dict>amb@world_human_leaning@male@wall@back@foot_up@idle_a</Dict>
					<Name>idle_a</Name>
					<Speed>4</Speed>
					<SpeedMultiplier>-4</SpeedMultiplier>
					<PlaybackRate>0</PlaybackRate>
					<Duration>-1</Duration>
					<Flag>49</Flag>
					<LockPos>false</LockPos>
				</Animation>
			</Animations>
```
While previously it would have only saved this:
```
			<AnimActive>true</AnimActive>
			<AnimDict>amb@world_human_leaning@male@wall@back@foot_up@idle_a</AnimDict>
			<AnimName>idle_a</AnimName>
```

All changes are also backwards compatible - loading .xml files saved before this update will work fine.