### PR TITLE
Gizmo improvements

### DIFF
--- a/Solution/source/Scripting/GTAentity.cpp
+++ b/Solution/source/Scripting/GTAentity.cpp
@@ -413,8 +413,8 @@ Vector3 GTAentity::GetScale() const
 	else
 	{
 		return {
-			GTAmemory::ReadFloat(ptr + 0x74),
 			GTAmemory::ReadFloat(ptr + 0x60),
+			GTAmemory::ReadFloat(ptr + 0x74),
 			GTAmemory::ReadFloat(ptr + 0x88)
 		};
 	}
@@ -462,8 +462,8 @@ void GTAentity::SetScale(Vector3 value)
 	}
 	else
 	{
-		GTAmemory::WriteFloat(ptr + 0x60, value.y);
-		GTAmemory::WriteFloat(ptr + 0x74, value.x);
+		GTAmemory::WriteFloat(ptr + 0x60, value.x);
+		GTAmemory::WriteFloat(ptr + 0x74, value.y);
 		GTAmemory::WriteFloat(ptr + 0x88, value.z);
 	}
 }

--- a/Solution/source/Scripting/GTAentity.cpp
+++ b/Solution/source/Scripting/GTAentity.cpp
@@ -398,6 +398,72 @@ void GTAentity::SetRotation(Vector3 value)
 	SET_ENTITY_ROTATION(this->mHandle, value.x, value.y, value.z, 2, 1);
 }
 
+Vector3 GTAentity::GetScale() const
+{
+	UINT64 ptr = GTAmemory::_entityAddressFunc(mHandle);
+	if (!ptr) return { 1.0f, 1.0f, 1.0f };
+
+	if (IsVehicle() || IsPed())
+	{
+		Vector3 r = GTAmemory::ReadVector3(ptr + 0x60);
+		Vector3 f = GTAmemory::ReadVector3(ptr + 0x70);
+		Vector3 u = GTAmemory::ReadVector3(ptr + 0x80);
+		return { r.Length(), f.Length(), u.Length() };
+	}
+	else
+	{
+		return {
+			GTAmemory::ReadFloat(ptr + 0x74),
+			GTAmemory::ReadFloat(ptr + 0x60),
+			GTAmemory::ReadFloat(ptr + 0x88)
+		};
+	}
+}
+
+void GTAentity::SetScale(Vector3 value)
+{
+	UINT64 ptr = GTAmemory::_entityAddressFunc(mHandle);
+	if (!ptr) return;
+
+	if (IsVehicle())
+	{
+		UINT64 drawPtr = *(UINT64*)(ptr + 0x30);
+		auto apply = [](UINT64 m, float sx, float sy, float sz) {
+			Vector3 r = GTAmemory::ReadVector3(m);
+			Vector3 f = GTAmemory::ReadVector3(m + 0x10);
+			Vector3 u = GTAmemory::ReadVector3(m + 0x20);
+			float lr = r.Length(), lf = f.Length(), lu = u.Length();
+			if (lr > 0.0001f) GTAmemory::WriteVector3(m, r * (sx / lr));
+			if (lf > 0.0001f) GTAmemory::WriteVector3(m + 0x10, f * (sy / lf));
+			if (lu > 0.0001f) GTAmemory::WriteVector3(m + 0x20, u * (sz / lu));
+		};
+		apply(ptr + 0x60, value.x, value.y, value.z);
+		if (drawPtr) apply(drawPtr + 0x20, value.x, value.y, value.z);
+		GTAmemory::WriteFloat(ptr + 0x60, value.x);
+		GTAmemory::WriteFloat(ptr + 0x74, value.y);
+		GTAmemory::WriteFloat(ptr + 0x88, value.z);
+	}
+	else if (IsPed())
+	{
+		auto apply = [](UINT64 m, float sx, float sy, float sz) {
+			Vector3 r = GTAmemory::ReadVector3(m);
+			Vector3 f = GTAmemory::ReadVector3(m + 0x10);
+			Vector3 u = GTAmemory::ReadVector3(m + 0x20);
+			float lr = r.Length(), lf = f.Length(), lu = u.Length();
+			if (lr > 0.0001f) GTAmemory::WriteVector3(m, r * (sx / lr));
+			if (lf > 0.0001f) GTAmemory::WriteVector3(m + 0x10, f * (sy / lf));
+			if (lu > 0.0001f) GTAmemory::WriteVector3(m + 0x20, u * (sz / lu));
+		};
+		apply(ptr + 0x60, value.x, value.y, value.z);
+	}
+	else
+	{
+		GTAmemory::WriteFloat(ptr + 0x60, value.y);
+		GTAmemory::WriteFloat(ptr + 0x74, value.x);
+		GTAmemory::WriteFloat(ptr + 0x88, value.z);
+	}
+}
+
 Vector3 GTAentity::GetDirection() const
 {
 	return Vector3::RotationToDirection(GET_ENTITY_ROTATION(this->mHandle, 2));

--- a/Solution/source/Scripting/GTAentity.cpp
+++ b/Solution/source/Scripting/GTAentity.cpp
@@ -425,6 +425,10 @@ void GTAentity::SetScale(Vector3 value)
 	UINT64 ptr = GTAmemory::_entityAddressFunc(mHandle);
 	if (!ptr) return;
 
+	value.x = max(0.01f, value.x);
+	value.y = max(0.01f, value.y);
+	value.z = max(0.01f, value.z);
+
 	if (IsVehicle())
 	{
 		UINT64 drawPtr = *(UINT64*)(ptr + 0x30);

--- a/Solution/source/Scripting/GTAentity.h
+++ b/Solution/source/Scripting/GTAentity.h
@@ -147,6 +147,8 @@ public:
 
 	Vector3 Rotation_get() const;
 	void SetRotation(Vector3 value);
+	Vector3 GetScale() const;
+	void SetScale(Vector3 value);
 	Vector3 GetDirection() const;
 	void SetDirection(Vector3 value);
 

--- a/Solution/source/Submenus/Spooner/ImGuiSpooner.cpp
+++ b/Solution/source/Submenus/Spooner/ImGuiSpooner.cpp
@@ -19,6 +19,7 @@
 #include "..\..\Scripting\GTAentity.h"
 #include "..\..\Util\GTAmath.h"
 #include "..\..\Natives\natives.h"
+#include "Submenus.h"
 
 namespace sub::Spooner::ImGuiSpooner
 {
@@ -315,29 +316,30 @@ namespace sub::Spooner::ImGuiSpooner
 		else if (op == ImGuizmo::SCALE)
 		{
 			static float s_DragMatrix[16];
-			static Vector3 s_LastScale{1.0f, 1.0f, 1.0f};
 
 			if (!ImGuizmo::IsUsing())
-			{
 				BuildTransformMatrix(s.position, s.rotation, s.scale, s_DragMatrix);
-				s_LastScale = s.scale;
-			}
 
-			ImGuizmo::Manipulate(viewMat, projMat, ImGuizmo::SCALE, ImGuizmo::LOCAL, s_DragMatrix, nullptr, nullptr);
+			float deltaMatrix[16] = {0};
+			ImGuizmo::Manipulate(viewMat, projMat, ImGuizmo::SCALE, ImGuizmo::LOCAL, s_DragMatrix, deltaMatrix, nullptr);
 
 			if (ImGuizmo::IsUsing())
 			{
-				Vector3 newPos, newRot, newScale;
-				DecomposeTransformMatrix(s_DragMatrix, newPos, newRot, newScale);
+				Vector3 deltaPos, deltaRot, deltaScale;
+				DecomposeTransformMatrix(deltaMatrix, deltaPos, deltaRot, deltaScale);
 
-				if (fabsf(newScale.x - s_LastScale.x) > FLT_EPSILON ||
-					fabsf(newScale.y - s_LastScale.y) > FLT_EPSILON ||
-					fabsf(newScale.z - s_LastScale.z) > FLT_EPSILON)
+				Vector3 newScale;
+				newScale.x = s.scale.x * deltaScale.x;
+				newScale.y = s.scale.y * deltaScale.y;
+				newScale.z = s.scale.z * deltaScale.z;
+
+				if (fabsf(newScale.x - s.scale.x) > FLT_EPSILON ||
+					fabsf(newScale.y - s.scale.y) > FLT_EPSILON ||
+					fabsf(newScale.z - s.scale.z) > FLT_EPSILON)
 				{
 					s.pending.scaleDirty = true;
 					s.pending.scaleVal = newScale;
 				}
-				s_LastScale = newScale;
 			}
 		}
 
@@ -462,8 +464,19 @@ namespace sub::Spooner::ImGuiSpooner
 				}
 			}
 			if (s.pending.scaleDirty) {
-				s.pending.scaleVal = {s.pending.scaleVal.y, s.pending.scaleVal.x, s.pending.scaleVal.z}; // scaling axes are weird
 				sel.handle.SetScale(s.pending.scaleVal);
+				// syncing scale so that it doesn't reset every time we grab the gizmo
+				Entity entHandle = sel.handle.GetHandle();
+				Submenus::EntityScaleState& state = [&]() -> Submenus::EntityScaleState& {
+					switch (static_cast<EntityType>(sel.handle.Type()))
+					{
+					case EntityType::VEHICLE: return Submenus::_vehScale;
+					case EntityType::PED:    return Submenus::_pedScale;
+					default:                 return Submenus::_objScale;
+					}
+				}();
+				state.handle = entHandle;
+				state.scale = s.pending.scaleVal;
 			}
 		}
 		s.pending = PendingWrites{};

--- a/Solution/source/Submenus/Spooner/ImGuiSpooner.cpp
+++ b/Solution/source/Submenus/Spooner/ImGuiSpooner.cpp
@@ -15,6 +15,7 @@
 
 #include "SpoonerEntity.h"
 #include "SpoonerMode.h"
+#include "SpoonerSettings.h"
 #include "..\..\Scripting\GTAentity.h"
 #include "..\..\Util\GTAmath.h"
 #include "..\..\Natives\natives.h"
@@ -240,7 +241,10 @@ namespace sub::Spooner::ImGuiSpooner
 			BuildTransformMatrix(s.position, s.rotation, Vector3(1.0f, 1.0f, 1.0f), matrix);
 
 			float deltaMatrix[16]{};
-			ImGuizmo::Manipulate(viewMat, projMat, op, gizmoMode, matrix, deltaMatrix, nullptr);
+			float snapMatrix[3] = { Settings::gridSnapSize, Settings::gridSnapSize, Settings::gridSnapSize };
+
+			ImGuizmo::Manipulate(viewMat, projMat, op, gizmoMode, matrix, deltaMatrix,
+				(Settings::bGridSnapEnabled && Settings::gridSnapSize > 0.0f) ? snapMatrix : nullptr);
 
 			if (ImGuizmo::IsUsing())
 			{
@@ -273,8 +277,10 @@ namespace sub::Spooner::ImGuiSpooner
 			}
 
 			float oldRot[3] = { s_LastEuler[0], s_LastEuler[1], s_LastEuler[2] };
-
-			ImGuizmo::Manipulate(viewMat, projMat, op, gizmoMode, s_DragMatrix, nullptr, nullptr);
+			float snapMatrix[3] = { Settings::rotationSnapDegrees, Settings::rotationSnapDegrees, Settings::rotationSnapDegrees };
+			
+			ImGuizmo::Manipulate(viewMat, projMat, op, gizmoMode, s_DragMatrix, nullptr,
+				(Settings::bGridSnapEnabled && Settings::rotationSnapDegrees > 0.0f) ? snapMatrix : nullptr);
 
 			if (ImGuizmo::IsUsing())
 			{

--- a/Solution/source/Submenus/Spooner/ImGuiSpooner.cpp
+++ b/Solution/source/Submenus/Spooner/ImGuiSpooner.cpp
@@ -26,6 +26,7 @@ namespace sub::Spooner::ImGuiSpooner
 	{
 		bool positionDirty = false;  Vector3 positionVal{};
 		bool rotationDirty = false;  Vector3 rotationVal{};
+		bool scaleDirty = false;     Vector3 scaleVal{1.0f, 1.0f, 1.0f};
 	};
 
 	struct SharedState
@@ -33,13 +34,14 @@ namespace sub::Spooner::ImGuiSpooner
 		bool entityValid = false;
 		Vector3 position{};
 		Vector3 rotation{};
+		Vector3 scale{1.0f, 1.0f, 1.0f};
 
 		// Active rendering camera
 		Vector3 camCoord{};
 		Vector3 camRot{};
 		float   camFov = 50.0f;
 
-		bool rotationMode = false;            // SpoonerMode::bEntityEditRotationMode
+		SpoonerMode::eGizmoMode gizmoMode = SpoonerMode::eGizmoMode::Translate; // SpoonerMode::gizmoMode
 		bool gizmoEditModeActive = false;     // entityEditMode == eEntityEditMode::Gizmo
 		bool cameraLocked = false;            // SpoonerMode::bGizmoCameraLocked
 		bool localSpace = false;              // SpoonerMode::bGizmoLocalSpace
@@ -232,7 +234,13 @@ namespace sub::Spooner::ImGuiSpooner
 		ImGuizmo::BeginFrame();
 		ImGuizmo::SetRect(0, 0, io.DisplaySize.x, io.DisplaySize.y);
 
-		ImGuizmo::OPERATION op = s.rotationMode ? ImGuizmo::ROTATE : ImGuizmo::TRANSLATE;
+		ImGuizmo::OPERATION op;
+		switch (s.gizmoMode)
+		{
+			case SpoonerMode::eGizmoMode::Rotate: op = ImGuizmo::ROTATE; break;
+			case SpoonerMode::eGizmoMode::Scale:  op = ImGuizmo::SCALE;  break;
+			default:                              op = ImGuizmo::TRANSLATE; break;
+		}
 		ImGuizmo::MODE gizmoMode = s.localSpace ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
 
 		if (op == ImGuizmo::TRANSLATE)
@@ -302,6 +310,34 @@ namespace sub::Spooner::ImGuiSpooner
 				s_LastEuler[0] = newRot.x;
 				s_LastEuler[1] = newRot.y;
 				s_LastEuler[2] = newRot.z;
+			}
+		}
+		else if (op == ImGuizmo::SCALE)
+		{
+			static float s_DragMatrix[16];
+			static Vector3 s_LastScale{1.0f, 1.0f, 1.0f};
+
+			if (!ImGuizmo::IsUsing())
+			{
+				BuildTransformMatrix(s.position, s.rotation, s.scale, s_DragMatrix);
+				s_LastScale = s.scale;
+			}
+
+			ImGuizmo::Manipulate(viewMat, projMat, ImGuizmo::SCALE, ImGuizmo::LOCAL, s_DragMatrix, nullptr, nullptr);
+
+			if (ImGuizmo::IsUsing())
+			{
+				Vector3 newPos, newRot, newScale;
+				DecomposeTransformMatrix(s_DragMatrix, newPos, newRot, newScale);
+
+				if (fabsf(newScale.x - s_LastScale.x) > FLT_EPSILON ||
+					fabsf(newScale.y - s_LastScale.y) > FLT_EPSILON ||
+					fabsf(newScale.z - s_LastScale.z) > FLT_EPSILON)
+				{
+					s.pending.scaleDirty = true;
+					s.pending.scaleVal = newScale;
+				}
+				s_LastScale = newScale;
 			}
 		}
 
@@ -425,6 +461,10 @@ namespace sub::Spooner::ImGuiSpooner
 					sel.handle.AttachTo(parentEntity, sel.attachmentArgs.boneIndex, sel.handle.GetIsCollisionEnabled(), sel.attachmentArgs.offset, sel.attachmentArgs.rotation);
 				}
 			}
+			if (s.pending.scaleDirty) {
+				s.pending.scaleVal = {s.pending.scaleVal.y, s.pending.scaleVal.x, s.pending.scaleVal.z}; // scaling axes are weird
+				sel.handle.SetScale(s.pending.scaleVal);
+			}
 		}
 		s.pending = PendingWrites{};
 	}
@@ -445,7 +485,7 @@ namespace sub::Spooner::ImGuiSpooner
 			s.camFov   = CAM::GET_GAMEPLAY_CAM_FOV();
 		}
 
-		s.rotationMode = SpoonerMode::bEntityEditRotationMode;
+		s.gizmoMode = SpoonerMode::gizmoMode;
 
 		const bool inGizmoNow = SpoonerMode::entityEditMode == SpoonerMode::eEntityEditMode::Gizmo;
 		static bool s_wasInGizmo = false;
@@ -463,11 +503,13 @@ namespace sub::Spooner::ImGuiSpooner
 		{
 			s.position = Vector3{};
 			s.rotation = Vector3{};
+			s.scale = Vector3{1.0f, 1.0f, 1.0f};
 			return;
 		}
 
 		s.position = sel.handle.GetPosition();
 		s.rotation = sel.handle.Rotation_get();
+		s.scale = sel.handle.GetScale();
 	}
 
 	void Tick()

--- a/Solution/source/Submenus/Spooner/SpoonerMode.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.cpp
@@ -963,66 +963,15 @@ namespace sub::Spooner
 			if (!Databases::MarkerDb.empty())
 				MarkerManagement::DrawAll();
 
-			if (Submenus::_vehScaleEntity != 0)
+			auto applyScaleTick = [](const Submenus::EntityScaleState& s)
 			{
-				float sx = Submenus::_vehScaleX, sy = Submenus::_vehScaleY, sz = Submenus::_vehScaleZ;
-				UINT64 ptr = GTAmemory::_entityAddressFunc(Submenus::_vehScaleEntity);
-				if (ptr)
-				{
-					UINT64 drawMatrixPtr = *(UINT64*)(ptr + 0x30);
-					if (drawMatrixPtr)
-					{
-						auto applyScale = [](UINT64 matrix, float sx, float sy, float sz)
-						{
-							Vector3 r = GTAmemory::ReadVector3(matrix + 0x00);
-							Vector3 f = GTAmemory::ReadVector3(matrix + 0x10);
-							Vector3 u = GTAmemory::ReadVector3(matrix + 0x20);
-							float lr = r.Length(), lf = f.Length(), lu = u.Length();
-							if (lr > 0.0001f) GTAmemory::WriteVector3(matrix + 0x00, r * (sx / lr));
-							if (lf > 0.0001f) GTAmemory::WriteVector3(matrix + 0x10, f * (sy / lf));
-							if (lu > 0.0001f) GTAmemory::WriteVector3(matrix + 0x20, u * (sz / lu));
-						};
-						applyScale(ptr + 0x60,          sx, sy, sz);
-						applyScale(drawMatrixPtr + 0x20, sx, sy, sz);
-						GTAmemory::WriteFloat(ptr + 0x60, sx);
-						GTAmemory::WriteFloat(ptr + 0x74, sy);
-						GTAmemory::WriteFloat(ptr + 0x88, sz);
-					}
-				}
-			}
-
-			if (Submenus::_pedScaleEntity != 0)
-			{
-				float sx = Submenus::_pedScaleX, sy = Submenus::_pedScaleY, sz = Submenus::_pedScaleZ;
-				UINT64 ptr = GTAmemory::_entityAddressFunc(Submenus::_pedScaleEntity);
-				if (ptr)
-				{
-					auto applyScale = [](UINT64 matrix, float sx, float sy, float sz)
-					{
-						Vector3 r = GTAmemory::ReadVector3(matrix + 0x00);
-						Vector3 f = GTAmemory::ReadVector3(matrix + 0x10);
-						Vector3 u = GTAmemory::ReadVector3(matrix + 0x20);
-						float lr = r.Length(), lf = f.Length(), lu = u.Length();
-						if (lr > 0.0001f) GTAmemory::WriteVector3(matrix + 0x00, r * (sx / lr));
-						if (lf > 0.0001f) GTAmemory::WriteVector3(matrix + 0x10, f * (sy / lf));
-						if (lu > 0.0001f) GTAmemory::WriteVector3(matrix + 0x20, u * (sz / lu));
-					};
-
-					applyScale(ptr + 0x60, sx, sy, sz);
-				}
-			}
-
-			if (Submenus::_objScaleEntity != 0)
-			{
-				float sx = Submenus::_objScaleX, sy = Submenus::_objScaleY, sz = Submenus::_objScaleZ;
-				UINT64 ptr = GTAmemory::_entityAddressFunc(Submenus::_objScaleEntity);
-				if (ptr)
-				{
-					GTAmemory::WriteFloat(ptr + 0x60, sy);
-					GTAmemory::WriteFloat(ptr + 0x74, sx);
-					GTAmemory::WriteFloat(ptr + 0x88, sz);
-				}
-			}
+				if (s.handle == 0) return;
+				GTAentity ent(s.handle);
+				ent.SetScale(s.scale);
+			};
+			applyScaleTick(Submenus::_vehScale);
+			applyScaleTick(Submenus::_pedScale);
+			applyScaleTick(Submenus::_objScale);
 		}
 
 		void TurnOn()

--- a/Solution/source/Submenus/Spooner/SpoonerMode.cpp
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.cpp
@@ -57,7 +57,7 @@ namespace sub::Spooner
 		bool bIsSomethingHeld = false;
 		bool bHeldEntityHasCollision = true;
 		eEntityEditMode entityEditMode = eEntityEditMode::Disabled;
-		bool bEntityEditRotationMode = false;
+		eGizmoMode gizmoMode = eGizmoMode::Translate;
 		bool bGizmoCameraLocked = false;
 		bool bGizmoLocalSpace = false;
 		Camera spoonerModeCamera;
@@ -103,6 +103,17 @@ namespace sub::Spooner
 				pos.z = round(pos.z / g) * g;
 			}
 			return pos;
+		}
+		Vector3 SnapRotation(Vector3 rot)
+		{
+			if (Settings::bGridSnapEnabled && Settings::rotationSnapDegrees > 0.0f)
+			{
+				float r = Settings::rotationSnapDegrees;
+				rot.x = round(rot.x / r) * r;
+				rot.y = round(rot.y / r) * r;
+				rot.z = round(rot.z / r) * r;
+			}
+			return rot;
 		}
 
 		ModelPreviewInfoStructure modelPreviewInfo = { EntityType::ALL, 0, 0, 0,{} };

--- a/Solution/source/Submenus/Spooner/SpoonerMode.h
+++ b/Solution/source/Submenus/Spooner/SpoonerMode.h
@@ -35,7 +35,8 @@ namespace sub::Spooner
 
 		enum class eEntityEditMode : UINT8 { Disabled, Keyboard, Gizmo };
 		extern eEntityEditMode entityEditMode;
-		extern bool bEntityEditRotationMode;
+		enum class eGizmoMode : UINT8 { Translate, Rotate, Scale };
+		extern eGizmoMode gizmoMode;
 		extern bool bGizmoCameraLocked;
 		extern bool bGizmoLocalSpace; // false = world-aligned, true = entity-local axes
 		extern Camera spoonerModeCamera;
@@ -67,6 +68,8 @@ namespace sub::Spooner
 		bool GetEntityPtr(GTAentity& inEntity, SpoonerEntity*& outEntity);
 		SpoonerEntity GetEntityPtrValue(GTAentity& entity);
 		inline void SetAsSelectedEntity(GTAentity& entity);
+		Vector3 SnapPos(Vector3 pos);
+		Vector3 SnapRotation(Vector3 rot);
 
 		inline void CamTick();
 		void Tick();

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -2049,8 +2049,8 @@ namespace sub
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
-			AddNumber("Scale X (Width)",  state.scale.x, 4, null, x_plus, x_minus);
-			AddNumber("Scale Y (Length)", state.scale.y, 4, null, y_plus, y_minus);
+			AddNumber("Scale X (Length)", state.scale.x, 4, null, x_plus, x_minus);
+			AddNumber("Scale Y (Width)",  state.scale.y, 4, null, y_plus, y_minus);
 			AddNumber("Scale Z (Height)", state.scale.z, 4, null, z_plus, z_minus);
 			AddOption("Reset scale", bResetScale);
 

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -2062,8 +2062,15 @@ namespace sub
 			if (z_minus) state.scale.z = max(0.01f, state.scale.z - _manualPlacementPrecision);
 
 			if (bResetScale) state.scale = Vector3(1.0f, 1.0f, 1.0f);
-			
-			selectedEntity.handle.SetScale(state.scale);
+
+			bool bScaleChanged = x_plus || x_minus || y_plus || y_minus || z_plus || z_minus || bResetScale;
+			if (bScaleChanged && !IS_ENTITY_A_VEHICLE(handle) && !IS_ENTITY_A_PED(handle))
+			{
+				selectedEntity.handle.SetIsCollisionEnabled(false);
+				selectedEntity.handle.FreezePosition(true);
+				selectedEntity.handle.SetScale(state.scale);
+			}
+
 		}
 
 		void Sub_QuickManualPlacement()

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -111,8 +111,9 @@ namespace sub
 				drawText("~b~=/-: ~w~+/- Sensitivity");
 				drawText("~b~R: ~w~Edit rotation");
 			}
+			drawText("~b~ALT: ~w~Copy entity");
 			drawText("~b~B: ~w~Switch to gizmo / disable controls.");
-
+ 
 			static DWORD lastSensitivityChange = 0;
 			if (IsKeyJustUp(VirtualKey::OEMPlus) && GetTickCount() - lastSensitivityChange > 200)
 			{
@@ -176,6 +177,7 @@ namespace sub
 			drawText("~b~R:~w~ Cycle mode");
 			drawText(SpoonerMode::bGizmoCameraLocked ? "~b~C:~w~ Unlock camera" : "~b~C:~w~ Lock camera");
 			drawText(SpoonerMode::bGizmoLocalSpace ? "~b~L:~w~ Edit in world space" : "~b~L:~w~ Edit in local space");
+			drawText("~b~ALT:~w~ Copy entity");
 			drawText("~b~B:~w~ Disable gizmo mode");
 		}
 
@@ -228,6 +230,17 @@ namespace sub
 			if (SpoonerMode::entityEditMode == SpoonerMode::eEntityEditMode::Gizmo && IsKeyJustUp(VirtualKey::L))
 			{
 				SpoonerMode::bGizmoLocalSpace = !SpoonerMode::bGizmoLocalSpace;
+			}
+
+			// make a quick copy of an entity by clicking ALT in editing modes
+			if (SpoonerMode::entityEditMode != SpoonerMode::eEntityEditMode::Disabled && IsKeyJustUp(VirtualKey::Menu))
+			{
+				if (selectedEntity.handle.Exists())
+				{
+					const SpoonerEntity& copiedEntity = EntityManagement::CopyEntity(selectedEntity, EntityManagement::GetEntityIndexInDb(selectedEntity) >= 0, true, _copyEntTexterValue);
+					selectedEntity = copiedEntity;
+					Game::Print::PrintBottomCentre("Entity copied.", 2500);
+				}
 			}
 
 			constexpr float HUD_LINE_HEIGHT = 0.025f;

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -98,7 +98,7 @@ namespace sub
 				hudY += HUD_LINE_HEIGHT;
 			};
 
-			if (SpoonerMode::bEntityEditRotationMode)
+			if (SpoonerMode::gizmoMode == SpoonerMode::eGizmoMode::Rotate)
 			{
 				drawText("~y~Rotation Mode:");
 				drawText("~b~W/S: ~w~Pitch+ / Pitch-");
@@ -132,13 +132,27 @@ namespace sub
 				Game::Print::PrintBottomCentre("Sensitivity: ~b~" + std::to_string(_manualPlacementPrecision), 3000);
 			}
 
-			auto& target = SpoonerMode::bEntityEditRotationMode ? rotation : position;
-			if (IsKeyDown(VirtualKey::W)) target.x += _manualPlacementPrecision;
-			if (IsKeyDown(VirtualKey::S)) target.x -= _manualPlacementPrecision;
-			if (IsKeyDown(VirtualKey::A)) target.y += _manualPlacementPrecision;
-			if (IsKeyDown(VirtualKey::D)) target.y -= _manualPlacementPrecision;
-			if (IsKeyDown(VirtualKey::E)) target.z += _manualPlacementPrecision;
-			if (IsKeyDown(VirtualKey::Q)) target.z -= _manualPlacementPrecision;
+			float step = _manualPlacementPrecision;
+			if (Settings::bGridSnapEnabled)
+			{
+				float snapAmount = SpoonerMode::gizmoMode == SpoonerMode::eGizmoMode::Rotate
+					? Settings::rotationSnapDegrees
+					: Settings::gridSnapSize;
+				if (snapAmount > 0.0f) step = snapAmount;
+			}
+
+			auto& target = SpoonerMode::gizmoMode == SpoonerMode::eGizmoMode::Rotate ? rotation : position;
+			if (IsKeyDown(VirtualKey::W)) target.x += step;
+			if (IsKeyDown(VirtualKey::S)) target.x -= step;
+			if (IsKeyDown(VirtualKey::A)) target.y += step;
+			if (IsKeyDown(VirtualKey::D)) target.y -= step;
+			if (IsKeyDown(VirtualKey::E)) target.z += step;
+			if (IsKeyDown(VirtualKey::Q)) target.z -= step;
+
+			if (SpoonerMode::gizmoMode == SpoonerMode::eGizmoMode::Rotate)
+				rotation = SpoonerMode::SnapRotation(rotation);
+			else
+				position = SpoonerMode::SnapPos(position);
 		}
 
 		void DrawGizmoHUD()
@@ -155,9 +169,16 @@ namespace sub
 				hudY += HUD_LINE_HEIGHT;
 			};
 
-			drawText(SpoonerMode::bEntityEditRotationMode ? "~y~Gizmo Mode ~s~(Rotation Mode):" : "~y~Gizmo Mode ~s~(Position Mode):");
+			std::string modeName;
+			switch (SpoonerMode::gizmoMode)
+			{
+				case SpoonerMode::eGizmoMode::Rotate: modeName = "Rotation"; break;
+				case SpoonerMode::eGizmoMode::Scale:  modeName = "Scale";    break;
+				default:                              modeName = "Position"; break;
+			}
+			drawText("~y~Gizmo Mode ~s~(" + modeName + " Mode):");
 			drawText("~b~Left Click:~w~ Grab axis handle");
-			drawText(SpoonerMode::bEntityEditRotationMode ? "~b~R:~w~ Edit position" : "~b~R:~w~ Edit rotation");
+			drawText("~b~R:~w~ Cycle mode");
 			drawText(SpoonerMode::bGizmoCameraLocked ? "~b~C:~w~ Unlock camera" : "~b~C:~w~ Lock camera");
 			drawText(SpoonerMode::bGizmoLocalSpace ? "~b~L:~w~ Edit in world space" : "~b~L:~w~ Edit in local space");
 			drawText("~b~B:~w~ Disable gizmo mode");
@@ -193,7 +214,12 @@ namespace sub
 			bool currentRToggle = IsKeyJustUp(VirtualKey::R);
 			if (currentRToggle && !lastRToggle)
 			{
-				SpoonerMode::bEntityEditRotationMode = !SpoonerMode::bEntityEditRotationMode;
+				switch (SpoonerMode::gizmoMode)
+				{
+					case SpoonerMode::eGizmoMode::Translate: SpoonerMode::gizmoMode = SpoonerMode::eGizmoMode::Rotate; break;
+					case SpoonerMode::eGizmoMode::Rotate:    SpoonerMode::gizmoMode = SpoonerMode::eGizmoMode::Scale;  break;
+					case SpoonerMode::eGizmoMode::Scale:     SpoonerMode::gizmoMode = SpoonerMode::eGizmoMode::Translate; break;
+				}
 			}
 			lastRToggle = currentRToggle;
 
@@ -230,6 +256,9 @@ namespace sub
 
 			if (SpoonerMode::entityEditMode == SpoonerMode::eEntityEditMode::Keyboard)
 			{
+				// keyboard edit mode doesn't support scaling, so we are switching to translate
+				if (SpoonerMode::gizmoMode == SpoonerMode::eGizmoMode::Scale)
+					SpoonerMode::gizmoMode = SpoonerMode::eGizmoMode::Translate;
 				HandleKeyboardManipulation(position, rotation);
 			}
 			else if (SpoonerMode::entityEditMode == SpoonerMode::eEntityEditMode::Gizmo)
@@ -1591,8 +1620,8 @@ namespace sub
 				bool z_plus = 0, z_minus = 0;
 				bool pitch_plus = 0, pitch_minus = 0;
 				bool roll_plus = 0, roll_minus = 0;
-				bool yaw_plus = 0, yaw_minus = 0,
-				bResetRot = 0;
+				bool yaw_plus = 0, yaw_minus = 0;
+				bool bResetRot = 0;
 
 				int nextBoneIndex = selectedEntity.attachmentArgs.boneIndex;
 				Vector3 nextOffset = selectedEntity.attachmentArgs.offset;

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -105,7 +105,7 @@ namespace sub
 				drawText("~b~A/D: ~w~Yaw+ / Yaw-");
 				drawText("~b~E/Q: ~w~Roll+ / Roll-");
 				drawText("~b~=/-: ~w~+/- Sensitivity");
-				drawText("~b~R: ~w~Toggle position");
+				drawText("~b~R: ~w~Edit position");
 			}
 			else
 			{
@@ -114,7 +114,7 @@ namespace sub
 				drawText("~b~A/D: ~w~Y+ / Y-");
 				drawText("~b~E/Q: ~w~Z+ / Z-");
 				drawText("~b~=/-: ~w~+/- Sensitivity");
-				drawText("~b~R: ~w~Toggle rotation");
+				drawText("~b~R: ~w~Edit rotation");
 			}
 			drawText("~b~B: ~w~Switch to gizmo / disable controls.");
 
@@ -123,11 +123,13 @@ namespace sub
 			{
 				if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10;
 				lastSensitivityChange = GetTickCount();
+				Game::Print::PrintBottomCentre("Sensitivity: ~b~" + std::to_string(_manualPlacementPrecision), 3000);
 			}
 			if (IsKeyJustUp(VirtualKey::OEMMinus) && GetTickCount() - lastSensitivityChange > 200)
 			{
 				if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10;
 				lastSensitivityChange = GetTickCount();
+				Game::Print::PrintBottomCentre("Sensitivity: ~b~" + std::to_string(_manualPlacementPrecision), 3000);
 			}
 
 			auto& target = SpoonerMode::bEntityEditRotationMode ? rotation : position;
@@ -155,10 +157,10 @@ namespace sub
 
 			drawText(SpoonerMode::bEntityEditRotationMode ? "~y~Gizmo Mode ~s~(Rotation Mode):" : "~y~Gizmo Mode ~s~(Position Mode):");
 			drawText("~b~Left Click:~w~ Grab axis handle");
-			drawText("~b~R:~w~ Toggle position/rotation");
-			drawText("~b~B:~w~ Disable gizmo mode");
+			drawText(SpoonerMode::bEntityEditRotationMode ? "~b~R:~w~ Edit position" : "~b~R:~w~ Edit rotation");
 			drawText(SpoonerMode::bGizmoCameraLocked ? "~b~C:~w~ Unlock camera" : "~b~C:~w~ Lock camera");
 			drawText(SpoonerMode::bGizmoLocalSpace ? "~b~L:~w~ Edit in world space" : "~b~L:~w~ Edit in local space");
+			drawText("~b~B:~w~ Disable gizmo mode");
 		}
 
 		void HandleEntityEditingLogic(Vector3& position, Vector3& rotation, GTAentity* parentEntity)
@@ -239,6 +241,7 @@ namespace sub
 	void Sub_SpoonerMain()
 		{
 			SpoonerMode::entityEditMode = SpoonerMode::eEntityEditMode::Disabled;
+			SpoonerMode::bGizmoCameraLocked = false;
 			selectedEntity.handle = 0;
 			_searchStr.clear(); // Sub_SaveFiles _searchStr
 			dict3.clear(); // Sub_SaveFiles _dir
@@ -1254,6 +1257,7 @@ namespace sub
 		void Sub_SelectedEntityOps()
 		{
 			SpoonerMode::entityEditMode = SpoonerMode::eEntityEditMode::Disabled;
+			SpoonerMode::bGizmoCameraLocked = false;
 			if (!selectedEntity.handle.Exists())
 			{
 				Menu::SetPreviousMenu();
@@ -1587,7 +1591,8 @@ namespace sub
 				bool z_plus = 0, z_minus = 0;
 				bool pitch_plus = 0, pitch_minus = 0;
 				bool roll_plus = 0, roll_minus = 0;
-				bool yaw_plus = 0, yaw_minus = 0;
+				bool yaw_plus = 0, yaw_minus = 0,
+				bResetRot = 0;
 
 				int nextBoneIndex = selectedEntity.attachmentArgs.boneIndex;
 				Vector3 nextOffset = selectedEntity.attachmentArgs.offset;
@@ -1713,6 +1718,7 @@ namespace sub
 				AddNumber("Pitch", nextRot.x, 4, null, pitch_plus, pitch_minus);
 				AddNumber("Roll", nextRot.y, 4, null, roll_plus, roll_minus);
 				AddNumber("Yaw", nextRot.z, 4, null, yaw_plus, yaw_minus);
+				AddOption("Reset rotation", bResetRot);
 
 				if (x_plus) nextOffset.x += _manualPlacementPrecision;
 				if (x_minus) nextOffset.x -= _manualPlacementPrecision;
@@ -1727,6 +1733,9 @@ namespace sub
 				if (roll_minus) nextRot.y -= _manualPlacementPrecision;
 				if (yaw_plus) nextRot.z += _manualPlacementPrecision;
 				if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+				if (bResetRot) nextRot = Vector3();
+
 
 				WrapAngle(nextRot.x);
 				WrapAngle(nextRot.y);
@@ -1927,7 +1936,8 @@ namespace sub
 				z_plus = 0, z_minus = 0,
 				pitch_plus = 0, pitch_minus = 0,
 				roll_plus = 0, roll_minus = 0,
-				yaw_plus = 0, yaw_minus = 0;
+				yaw_plus = 0, yaw_minus = 0,
+				bResetRot = 0;
 
 			AddTitle("Manual Placement");
 			AddNumber("Scroll Sensitivity", _manualPlacementPrecision, 4, null, prec_minus, prec_plus);
@@ -1937,6 +1947,7 @@ namespace sub
 			AddNumber("Pitch", currRot.x, 4, null, pitch_plus, pitch_minus);
 			AddNumber("Roll", currRot.y, 4, null, roll_plus, roll_minus);
 			AddNumber("Yaw", currRot.z, 4, null, yaw_plus, yaw_minus);
+			AddOption("Reset rotation", bResetRot);
 
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
@@ -1956,6 +1967,8 @@ namespace sub
 			if (roll_minus) nextRot.y -= _manualPlacementPrecision;
 			if (yaw_plus) nextRot.z += _manualPlacementPrecision;
 			if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+		
+			if (bResetRot) nextRot = Vector3();
 
 			WrapAngle(nextRot.x);
 			WrapAngle(nextRot.y);
@@ -2205,7 +2218,8 @@ namespace sub
 				z_plus = 0, z_minus = 0,
 				pitch_plus = 0, pitch_minus = 0,
 				roll_plus = 0, roll_minus = 0,
-				yaw_plus = 0, yaw_minus = 0;
+				yaw_plus = 0, yaw_minus = 0,
+				bResetRot = 0;
 
 			AddNumber("Scroll Sensitivity", _manualPlacementPrecision, 4, null, prec_minus, prec_plus);
 			AddNumber("X", currPos.x, 4, null, x_plus, x_minus);
@@ -2214,6 +2228,7 @@ namespace sub
 			AddNumber("Pitch", currRot.x, 4, null, pitch_plus, pitch_minus);
 			AddNumber("Roll", currRot.y, 4, null, roll_plus, roll_minus);
 			AddNumber("Yaw", currRot.z, 4, null, yaw_plus, yaw_minus);
+			AddOption("Reset rotation", bResetRot);
 			AddOption("Other Properites", null, nullFunc, SUB::SPOONER_SELECTEDENTITYOPS);
 
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
@@ -2234,6 +2249,8 @@ namespace sub
 			if (roll_minus) nextRot.y -= _manualPlacementPrecision;
 			if (yaw_plus) nextRot.z += _manualPlacementPrecision;
 			if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+			if (bResetRot) nextRot = Vector3();
 
 			WrapAngle(nextRot.x);
 			WrapAngle(nextRot.y);
@@ -2266,7 +2283,8 @@ namespace sub
 				z_plus = 0, z_minus = 0,
 				pitch_plus = 0, pitch_minus = 0,
 				roll_plus = 0, roll_minus = 0,
-				yaw_plus = 0, yaw_minus = 0;
+				yaw_plus = 0, yaw_minus = 0,
+				bResetRot = 0;
 
 			AddNumber("Scroll Sensitivity", _manualPlacementPrecision, 4, null, prec_minus, prec_plus);
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
@@ -2295,13 +2313,16 @@ namespace sub
 				AddNumber("Pitch", currRot.x, 4, null, pitch_plus, pitch_minus);
 				AddNumber("Roll", currRot.y, 4, null, roll_plus, roll_minus);
 				AddNumber("Yaw", currRot.z, 4, null, yaw_plus, yaw_minus);
-				
+				AddOption("Reset rotation", bResetRot);
+
 				if (pitch_plus) nextRot.x += _manualPlacementPrecision;
 				if (pitch_minus) nextRot.x -= _manualPlacementPrecision;
 				if (roll_plus) nextRot.y += _manualPlacementPrecision;
 				if (roll_minus) nextRot.y -= _manualPlacementPrecision;
 				if (yaw_plus) nextRot.z += _manualPlacementPrecision;
 				if (yaw_minus) nextRot.z -= _manualPlacementPrecision;
+
+				if (bResetRot) { *std::get<2>(SpoonerVector3ManualPlacementPtrs) = Vector3(); }
 
 				WrapAngle(nextRot.x);
 				WrapAngle(nextRot.y);

--- a/Solution/source/Submenus/Spooner/Submenus.cpp
+++ b/Solution/source/Submenus/Spooner/Submenus.cpp
@@ -75,12 +75,7 @@ namespace sub
 		float _fSaveRangeRadius = 5.0f;
 		UINT8 _copyEntTexterValue = 0;
 		UINT8 _entTypeToShowTexterValue = 0;
-		Entity _vehScaleEntity = 0;
-		float _vehScaleX = 1.0f, _vehScaleY = 1.0f, _vehScaleZ = 1.0f;
-		Entity _pedScaleEntity = 0;
-		float _pedScaleX = 1.0f, _pedScaleY = 1.0f, _pedScaleZ = 1.0f;
-		Entity _objScaleEntity = 0;
-		float _objScaleX = 1.0f, _objScaleY = 1.0f, _objScaleZ = 1.0f;
+		EntityScaleState _vehScale, _pedScale, _objScale;
 		void SetEnt241() { g_Ped1 = selectedEntity.handle.Handle(); }
 		void SetEnt12() { g_Ped4 = selectedEntity.handle.Handle(); }
 
@@ -2032,135 +2027,43 @@ namespace sub
 
 			AddTitle("Size Manipulation");
 
-			UINT64 ptr = GTAmemory::_entityAddressFunc(selectedEntity.handle.Handle());
-			if (!ptr) return;
-
 			Entity handle = selectedEntity.handle.Handle();
+
+			auto& state = IS_ENTITY_A_VEHICLE(handle) ? _vehScale
+			            : IS_ENTITY_A_PED(handle) ? _pedScale
+			            : _objScale;
+
+			if (state.handle != handle)
+			{
+				state.handle = handle;
+				state.scale = selectedEntity.handle.GetScale();
+			}
 
 			bool prec_plus = false, prec_minus = false;
 			bool x_plus = false, x_minus = false;
 			bool y_plus = false, y_minus = false;
 			bool z_plus = false, z_minus = false;
+			bool bResetScale = false;
 
 			AddNumber("Scroll Sensitivity", _manualPlacementPrecision, 4, null, prec_minus, prec_plus);
-
 			if (prec_plus) { if (_manualPlacementPrecision < 10.0f) _manualPlacementPrecision *= 10; }
 			if (prec_minus) { if (_manualPlacementPrecision > 0.0001f) _manualPlacementPrecision /= 10; }
 
-			if (IS_ENTITY_A_VEHICLE(handle))
-			{
-				UINT64 physicsMatrix = ptr + 0x60;
-				UINT64 drawMatrixPtr = *(UINT64*)(ptr + 0x30);
-				if (!drawMatrixPtr) return;
-				UINT64 vehicleMatrix = drawMatrixPtr + 0x20;
+			AddNumber("Scale X (Width)",  state.scale.x, 4, null, x_plus, x_minus);
+			AddNumber("Scale Y (Length)", state.scale.y, 4, null, y_plus, y_minus);
+			AddNumber("Scale Z (Height)", state.scale.z, 4, null, z_plus, z_minus);
+			AddOption("Reset scale", bResetScale);
 
-				// Reset stored scale when entity changes
-				if (_vehScaleEntity != handle)
-				{
-					_vehScaleEntity = handle;
-					Vector3 row = GTAmemory::ReadVector3(physicsMatrix + 0x00);
-					_vehScaleX = row.Length();
-					row = GTAmemory::ReadVector3(physicsMatrix + 0x10);
-					_vehScaleY = row.Length();
-					row = GTAmemory::ReadVector3(physicsMatrix + 0x20);
-					_vehScaleZ = row.Length();
-				}
+			if (x_plus)  state.scale.x = max(0.01f, state.scale.x + _manualPlacementPrecision);
+			if (x_minus) state.scale.x = max(0.01f, state.scale.x - _manualPlacementPrecision);
+			if (y_plus)  state.scale.y = max(0.01f, state.scale.y + _manualPlacementPrecision);
+			if (y_minus) state.scale.y = max(0.01f, state.scale.y - _manualPlacementPrecision);
+			if (z_plus)  state.scale.z = max(0.01f, state.scale.z + _manualPlacementPrecision);
+			if (z_minus) state.scale.z = max(0.01f, state.scale.z - _manualPlacementPrecision);
 
-				AddNumber("Scale X (Width)",  _vehScaleX, 4, null, x_plus, x_minus);
-				AddNumber("Scale Y (Length)", _vehScaleY, 4, null, y_plus, y_minus);
-				AddNumber("Scale Z (Height)", _vehScaleZ, 4, null, z_plus, z_minus);
-
-				if (x_plus)  _vehScaleX = max(0.001f, _vehScaleX + _manualPlacementPrecision);
-				if (x_minus) _vehScaleX = max(0.001f, _vehScaleX - _manualPlacementPrecision);
-				if (y_plus)  _vehScaleY = max(0.001f, _vehScaleY + _manualPlacementPrecision);
-				if (y_minus) _vehScaleY = max(0.001f, _vehScaleY - _manualPlacementPrecision);
-				if (z_plus)  _vehScaleZ = max(0.001f, _vehScaleZ + _manualPlacementPrecision);
-				if (z_minus) _vehScaleZ = max(0.001f, _vehScaleZ - _manualPlacementPrecision);
-
-				auto applyScale = [](UINT64 matrix, float sx, float sy, float sz)
-				{
-					Vector3 r = GTAmemory::ReadVector3(matrix + 0x00);
-					Vector3 f = GTAmemory::ReadVector3(matrix + 0x10);
-					Vector3 u = GTAmemory::ReadVector3(matrix + 0x20);
-					float lr = r.Length(), lf = f.Length(), lu = u.Length();
-					if (lr > 0.0001f) GTAmemory::WriteVector3(matrix + 0x00, r * (sx / lr));
-					if (lf > 0.0001f) GTAmemory::WriteVector3(matrix + 0x10, f * (sy / lf));
-					if (lu > 0.0001f) GTAmemory::WriteVector3(matrix + 0x20, u * (sz / lu));
-				};
-
-				applyScale(physicsMatrix, _vehScaleX, _vehScaleY, _vehScaleZ);
-				applyScale(vehicleMatrix,   _vehScaleX, _vehScaleY, _vehScaleZ);
-			}
-			else if (IS_ENTITY_A_PED(handle))
-			{
-				if (_pedScaleEntity != handle)
-				{
-					_pedScaleEntity = handle;
-					_pedScaleX = GTAmemory::ReadVector3(ptr + 0x60).Length();
-					_pedScaleY = GTAmemory::ReadVector3(ptr + 0x70).Length();
-					_pedScaleZ = GTAmemory::ReadVector3(ptr + 0x80).Length();
-				}
-
-				AddNumber("Scale X (Width)",  _pedScaleX, 4, null, x_plus, x_minus);
-				AddNumber("Scale Y (Length)", _pedScaleY, 4, null, y_plus, y_minus);
-				AddNumber("Scale Z (Height)", _pedScaleZ, 4, null, z_plus, z_minus);
-
-				if (x_plus)  _pedScaleX = max(0.001f, _pedScaleX + _manualPlacementPrecision);
-				if (x_minus) _pedScaleX = max(0.001f, _pedScaleX - _manualPlacementPrecision);
-				if (y_plus)  _pedScaleY = max(0.001f, _pedScaleY + _manualPlacementPrecision);
-				if (y_minus) _pedScaleY = max(0.001f, _pedScaleY - _manualPlacementPrecision);
-				if (z_plus)  _pedScaleZ = max(0.001f, _pedScaleZ + _manualPlacementPrecision);
-				if (z_minus) _pedScaleZ = max(0.001f, _pedScaleZ - _manualPlacementPrecision);
-
-				auto applyScale = [](UINT64 matrix, float sx, float sy, float sz)
-				{
-					Vector3 r = GTAmemory::ReadVector3(matrix + 0x00);
-					Vector3 f = GTAmemory::ReadVector3(matrix + 0x10);
-					Vector3 u = GTAmemory::ReadVector3(matrix + 0x20);
-					float lr = r.Length(), lf = f.Length(), lu = u.Length();
-					if (lr > 0.0001f) GTAmemory::WriteVector3(matrix + 0x00, r * (sx / lr));
-					if (lf > 0.0001f) GTAmemory::WriteVector3(matrix + 0x10, f * (sy / lf));
-					if (lu > 0.0001f) GTAmemory::WriteVector3(matrix + 0x20, u * (sz / lu));
-				};
-
-				applyScale(ptr + 0x60, _pedScaleX, _pedScaleY, _pedScaleZ);
-			}
-			else // IS_ENTITY_AN_OBJECT
-			{
-				// Reset stored scale when entity changes
-				if (_objScaleEntity != handle)
-				{
-					_objScaleEntity = handle;
-					_objScaleY = GTAmemory::ReadFloat(ptr + 0x60); // length
-					_objScaleX = GTAmemory::ReadFloat(ptr + 0x74); // width
-					_objScaleZ = GTAmemory::ReadFloat(ptr + 0x88); // height
-				}
-
-				AddNumber("Length (Y)", _objScaleY, 4, null, y_plus, y_minus);
-				AddNumber("Width (X)",  _objScaleX, 4, null, x_plus, x_minus);
-				AddNumber("Height (Z)", _objScaleZ, 4, null, z_plus, z_minus);
-
-				if (y_plus)  _objScaleY += (_manualPlacementPrecision * 25.0f);
-				if (y_minus) _objScaleY -= (_manualPlacementPrecision * 25.0f);
-				if (x_plus)  _objScaleX += (_manualPlacementPrecision * 25.0f);
-				if (x_minus) _objScaleX -= (_manualPlacementPrecision * 25.0f);
-				if (z_plus)  _objScaleZ += (_manualPlacementPrecision * 25.0f);
-				if (z_minus) _objScaleZ -= (_manualPlacementPrecision * 25.0f);
-
-				if (y_plus || y_minus || x_plus || x_minus || z_plus || z_minus)
-				{
-					selectedEntity.handle.SetIsCollisionEnabled(false);
-					selectedEntity.handle.FreezePosition(true);
-				}
-
-				if (_objScaleY < 0.01f) _objScaleY = 0.01f;
-				if (_objScaleX < 0.01f) _objScaleX = 0.01f;
-				if (_objScaleZ < 0.01f) _objScaleZ = 0.01f;
-
-				GTAmemory::WriteFloat(ptr + 0x60, _objScaleY);
-				GTAmemory::WriteFloat(ptr + 0x74, _objScaleX);
-				GTAmemory::WriteFloat(ptr + 0x88, _objScaleZ);
-			}
+			if (bResetScale) state.scale = Vector3(1.0f, 1.0f, 1.0f);
+			
+			selectedEntity.handle.SetScale(state.scale);
 		}
 
 		void Sub_QuickManualPlacement()

--- a/Solution/source/Submenus/Spooner/Submenus.h
+++ b/Solution/source/Submenus/Spooner/Submenus.h
@@ -34,7 +34,7 @@ namespace sub
 		extern float _pedScaleX, _pedScaleY, _pedScaleZ;
 		extern int _objScaleEntity;
 		extern float _objScaleX, _objScaleY, _objScaleZ;
-
+		
 		void HandleKeyboardPlacementInput(Vector3& position, Vector3& rotation);
 
 		void SetEnt241();

--- a/Solution/source/Submenus/Spooner/Submenus.h
+++ b/Solution/source/Submenus/Spooner/Submenus.h
@@ -28,12 +28,11 @@ namespace sub
 		extern std::tuple<GTAentity, Vector3*, Vector3*> SpoonerVector3ManualPlacementPtrs;
 		extern float _manualPlacementPrecision;
 		extern UINT8 _copyEntTexterValue;
-		extern int _vehScaleEntity;
-		extern float _vehScaleX, _vehScaleY, _vehScaleZ;
-		extern int _pedScaleEntity;
-		extern float _pedScaleX, _pedScaleY, _pedScaleZ;
-		extern int _objScaleEntity;
-		extern float _objScaleX, _objScaleY, _objScaleZ;
+		struct EntityScaleState {
+			int handle = 0;
+			Vector3 scale{ 1.0f, 1.0f, 1.0f };
+		};
+		extern EntityScaleState _vehScale, _pedScale, _objScale;
 		
 		void HandleKeyboardPlacementInput(Vector3& position, Vector3& rotation);
 


### PR DESCRIPTION
This PR adresses feedback regarding the gizmo mode.

Short summary of changes:
- added a notification when changing sensitivity in keyboard editing mode
- added "reset rotation" and "reset scale" buttons to Manual Placement, Attachment Ops and Scaling menus
- added support for snapping to gizmo and keyboard editing mode
- added scaling mode to gizmo
- added entity quick-copy to keyboard / gizmo editing (ALT)
- fixed camera remaining locked after disabling gizmo
- refactored old scaling menu and Tick() to reduce repeating code, added GetScale and SetScale methods for Entities.
